### PR TITLE
added support for pyqt5

### DIFF
--- a/doc/api/pyudev.pyqt5.rst
+++ b/doc/api/pyudev.pyqt5.rst
@@ -1,0 +1,37 @@
+:mod:`pyudev.pyqt5` – PyQt5_ integration
+========================================
+
+.. automodule:: pyudev.pyqt5
+   :platform: Linux
+   :synopsis: PyQt5 integration
+
+.. autoclass:: MonitorObserver
+
+   .. automethod:: __init__
+
+   .. attribute:: monitor
+
+      The :class:`~pyudev.Monitor` observed by this object.
+
+   .. attribute:: notifier
+
+      The underlying :class:`QtCore.QSocketNotifier` used to watch the
+      :attr:`monitor`.
+
+   .. autoattribute:: enabled
+
+   .. rubric:: Signals
+
+   This class emits the following Qt signal:
+
+   .. method:: deviceEvent(device)
+
+      Emitted upon any device event.
+
+      ``device`` is the :class:`~pyudev.Device` object describing the device.
+
+      Use :attr:`~pyudev.Device.action` to get the type of event.
+
+
+
+.. _PyQt5: http://riverbankcomputing.co.uk/software/pyqt/intro

--- a/pyudev/pyqt5.py
+++ b/pyudev/pyqt5.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+# This library is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by the
+# Free Software Foundation; either version 2.1 of the License, or (at your
+# option) any later version.
+
+# This library is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+# for more details.
+
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+"""
+    pyudev.pyqt5
+    ============
+
+    PyQt5 integration.
+
+    :class:`MonitorObserver` integrates device monitoring into the PyQt5_
+    mainloop by turing device events into Qt signals.
+
+    :mod:`PyQt5.QtCore` from PyQt5_ must be available when importing this
+    module.
+
+    .. _gPyQt5: http://riverbankcomputing.co.uk/software/pyqt/intro
+
+    .. moduleauthor::  Tobias Gehring  <mail@tobiasgehring.de>, Sebastian Wiesner  <lunaryorn@gmail.com>
+"""
+
+
+from __future__ import (print_function, division, unicode_literals,
+                        absolute_import)
+
+from PyQt5.QtCore import QSocketNotifier, QObject, pyqtSignal
+
+from pyudev.core import Device
+from pyudev._qt_base import MonitorObserverMixin
+
+
+class MonitorObserver(QObject, MonitorObserverMixin):
+    """An observer for device events integrating into the :mod:`PyQt5` mainloop.
+
+    This class inherits :class:`~PyQt5.QtCore.QObject` to turn device events
+    into Qt signals:
+
+    >>> from pyudev import Context, Monitor
+    >>> from pyudev.pyqt5 import MonitorObserver
+    >>> context = Context()
+    >>> monitor = Monitor.from_netlink(context)
+    >>> monitor.filter_by(subsystem='input')
+    >>> observer = MonitorObserver(monitor)
+    >>> def device_event(device):
+    ...     print('event {0} on device {1}'.format(device.action, device))
+    >>> observer.deviceEvent.connect(device_event)
+    >>> monitor.start()
+
+    This class is a child of :class:`~PyQt5.QtCore.QObject`.
+
+    """
+
+    #: emitted upon arbitrary device events
+    deviceEvent = pyqtSignal(Device)
+
+    def __init__(self, monitor, parent=None):
+        """
+        Observe the given ``monitor`` (a :class:`~pyudev.Monitor`):
+
+        ``parent`` is the parent :class:`~PyQt5.QtCore.QObject` of this
+        object.  It is passed unchanged to the inherited constructor of
+        :class:`~PyQt5.QtCore.QObject`.
+        """
+        QObject.__init__(self, parent)
+        self._setup_notifier(monitor, QSocketNotifier)

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -157,6 +157,10 @@ class TestPyQt4Observer(QtObserverTestBase):
     BINDING_NAME = 'PyQt4'
 
 
+class TestPyQt5Observer(QtObserverTestBase):
+    BINDING_NAME = 'PyQt5'
+
+
 class TestGlibObserver(ObserverTestBase):
 
     def setup(self):


### PR DESCRIPTION
Hi,

I added support for pyqt5 to pyudev. What I did is that I took the pyqt4 module and replaced all 4s with 5s which seems to do the trick. I didn't run the test suite but I tested the pyqt5 monitor with one of my pyqt5 applications.

Cheers, 
Tobias