### PR TITLE
Bug fix: allows defaults in all Attributes.as* methods.

### DIFF
--- a/src/pyudev/device/_device.py
+++ b/src/pyudev/device/_device.py
@@ -986,7 +986,8 @@ class Attributes(object):
         ``attribute`` is a unicode or byte string containing the name of the
         system attribute.
 
-        :param str attribute: the attribute to lookup
+        :param attribute: the attribute to lookup
+        :type attribute: unicode or byte string
         :param object default: the default value to return
         :returns: the attribute value or None if no value
         :rtype: byte string or NoneType
@@ -999,9 +1000,9 @@ class Attributes(object):
         )
         return value if value is not None else default
 
-    def asstring(self, attribute):
+    def asstring(self, attribute, default=u''):
         """
-        Get the given ``atribute`` for the device as unicode string.
+        Get the given ``attribute`` for the device as unicode string.
 
         Depending on the content of the attribute, this may or may not work.
         Be prepared to catch :exc:`~exceptions.UnicodeDecodeError`.
@@ -1010,14 +1011,20 @@ class Attributes(object):
         attribute.
 
         Return the attribute value as byte string.  Raise a
-        :exc:`~exceptions.KeyError`, if the given attribute is not defined
-        for this device, or :exc:`~exceptions.UnicodeDecodeError`, if the
+        :exc:`~exceptions.UnicodeDecodeError`, if the
         content of the attribute cannot be decoded into a unicode string.
-        """
-        value = self.get(attribute)
-        return ensure_unicode_string(value if value is not None else str(None))
 
-    def asint(self, attribute):
+        :param attribute: the lookup key
+        :type attribute: unicode or byte string
+        :param default: the default value to return if unavailable
+        :type default: unicode or byte string, default is u''
+        :raises UnicodeDecodeError: if result can not be converted
+        :returns: the contents of the attribute or the default
+        :rtype: unicode string
+        """
+        return ensure_unicode_string(self.get(attribute, default))
+
+    def asint(self, attribute, default=u''):
         """
         Get the given ``attribute`` as integer.
 
@@ -1025,13 +1032,21 @@ class Attributes(object):
         attribute.
 
         Return the attribute value as integer. Raise a
-        :exc:`~exceptions.KeyError`, if the given attribute is not defined
-        for this device, or a :exc:`~exceptions.ValueError`, if the
+        :exc:`~exceptions.ValueError`, if the
         attribute value cannot be converted to an integer.
-        """
-        return int(self.asstring(attribute))
 
-    def asbool(self, attribute):
+        :param attribute: the lookup key
+        :type attribute: unicode or byte string
+        :param default: the default value to return if unavailable
+        :type default: unicode or byte string, default is u''
+        :raises ValueError: if conversion fails
+        :raises UnicodeDecodeError: if value can not be converted to unicode
+        :returns: the contents of the attribute as an int
+        :rtype: int
+        """
+        return int(self.asstring(attribute, default))
+
+    def asbool(self, attribute, default=u''):
         """
         Get the given ``attribute`` from this device as boolean.
 
@@ -1044,10 +1059,19 @@ class Attributes(object):
 
         Return ``True``, if the attribute value is ``'1'`` and ``False``, if
         the attribute value is ``'0'``.  Any other value raises a
-        :exc:`~exceptions.ValueError`.  Raise a :exc:`~exceptions.KeyError`,
-        if the given attribute is not defined for this device.
+        :exc:`~exceptions.ValueError`.
+
+        :param attribute: the lookup key
+        :type attribute: unicode or byte string
+        :param default: the default value to return if unavailable
+        :type default: unicode or byte string, default is u''
+        :raises ValueError: if string is not '1' or '0'
+        :raises UnicodeDecodeError: if value can not be converted to unicode
+        :returns: the contents of the attribute
+        :rtype: bool
         """
-        return string_to_bool(self.asstring(attribute))
+        return string_to_bool(self.asstring(attribute, default))
+
 
 class Tags(Iterable, Container):
     """

--- a/tests/_device_tests/_attributes_tests.py
+++ b/tests/_device_tests/_attributes_tests.py
@@ -96,6 +96,15 @@ class TestAttributes(object):
     @given(
        _CONTEXT_STRATEGY,
        strategies.sampled_from(_DEVICE_DATA),
+       settings=Settings(max_examples=2)
+    )
+    def test_asstring_bogus_value(self, a_context, device_datum):
+        device = Device.from_path(a_context, device_datum.device_path)
+        assert device.attributes.asstring("totally bogus") == u''
+
+    @given(
+       _CONTEXT_STRATEGY,
+       strategies.sampled_from(_DEVICE_DATA),
        settings=Settings(max_examples=5)
     )
     def test_asint(self, a_context, device_datum):

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -313,8 +313,17 @@ class TestMonitorObserver(object):
 
     def make_observer(self, monitor, use_deprecated=False):
         if use_deprecated:
-            self.observer = pytest.deprecated_call(
-                MonitorObserver, monitor, event_handler=self.event_handler)
+            if pytest.__version__ == '2.8.4':
+                self.observer = MonitorObserver(
+                   monitor,
+                   event_handler=self.event_handler
+                )
+            else:
+                self.observer = pytest.deprecated_call(
+                   MonitorObserver,
+                   monitor,
+                   event_handler=self.event_handler
+                )
         else:
             self.observer = MonitorObserver(monitor, callback=self.callback)
         return self.observer


### PR DESCRIPTION
Since Attributes can not inherit the Mapping interface, these methods can
not usefully raise a KeyError.

On the other hand, it is reasonable to expect that they will return values
in their designated type.

The string "None" is a bad choice to represent a null result,
because it is a non-empty string.
The empty string is a somewhat better choice, so that is what
asstring() now returns if lookup is unsuccesful. Previously it returned
"None".  Prior to commit 609a08c3cb4baf09135be344bc8913cdbbe5d053, the
method would raise a KeyError.

This does not affect the behavior of asint(), or asbool(), which will raise
a ValueError on "None" or "".

Going forward, this allows setting a default which might be meaningful for
asint() or asbool() methods.

Of course, using asstring(), asbool(), asint(), prevents the client code
from distinguishing a value that was not found from a value that was found
or is the empty string. In general, these are methods best avoided.

Signed-off-by: mulhern <amulhern@redhat.com>