### PR TITLE
Don't crash if device list changes while enumerating devices.

### DIFF
--- a/src/pyudev/core.py
+++ b/src/pyudev/core.py
@@ -35,6 +35,7 @@ except ImportError:
     from pyudev._compat import check_output
 
 from pyudev.device import Device
+from pyudev.device._errors import DeviceNotFoundAtPathError
 from pyudev._libudev import load_udev_library
 from pyudev._util import (ensure_unicode_string, ensure_byte_string,
                           udev_list_iterate, property_value_to_bytes)
@@ -417,4 +418,7 @@ class Enumerator(object):
         self._libudev.udev_enumerate_scan_devices(self)
         entry = self._libudev.udev_enumerate_get_list_entry(self)
         for name, _ in udev_list_iterate(self._libudev, entry):
-            yield Device.from_sys_path(self.context, name)
+            try:
+                yield Device.from_sys_path(self.context, name)
+            except DeviceNotFoundAtPathError:
+                continue


### PR DESCRIPTION
I hit this while testing uevent support in blivet. I'm not totally sure this is how you want to handle this situation, but I imagine you'll want to do something other than raise `DeviceNotFoundAtPathError`.