### PR TITLE
Develop 0.21 properties

### DIFF
--- a/reproducers/1346446.c
+++ b/reproducers/1346446.c
@@ -1,0 +1,41 @@
+#include <stdio.h>
+#include <libudev.h>
+
+int main() {
+    int res;
+    struct udev * context;
+    struct udev_enumerate * enumerator;
+    struct udev_device * device;
+    struct udev_list_entry * entry;
+    char const * name;
+    context = udev_new();
+    enumerator = udev_enumerate_new(context);
+
+    // Uncomment below to get no match
+    //res = udev_enumerate_add_nomatch_subsystem(enumerator, "i2c");
+    //if (res < 0) {
+    //    return res;
+    //}
+
+    // Uncomment below to get match
+    //res = udev_enumerate_add_match_subsystem(enumerator, "i2c");
+    //if (res < 0) {
+    //    return res;
+    //}
+
+    // Leave both commented out to do no selection.
+
+    res = udev_enumerate_scan_devices(enumerator);
+    if (res < 0) {
+        return res;
+    }
+
+    entry = udev_enumerate_get_list_entry(enumerator);
+    while (entry) {
+        name = udev_list_entry_get_name(entry);
+        printf("%s\n", name);
+        entry = udev_list_entry_get_next(entry);
+    }
+
+    return 0;
+}

--- a/reproducers/1347299.c
+++ b/reproducers/1347299.c
@@ -1,0 +1,42 @@
+#include <stdio.h>
+#include <libudev.h>
+
+int main() {
+    int res;
+    struct udev * context;
+    struct udev_enumerate * enumerator;
+    struct udev_device * device;
+    struct udev_list_entry * entry;
+    char const * name;
+    char const * path;
+    context = udev_new();
+    enumerator = udev_enumerate_new(context);
+    device = udev_device_new_from_syspath(context, "/sys/devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A08:00");
+
+    path = udev_device_get_sysattr_value(device, "path");
+    printf("path before: %s\n", path);
+
+    // Uncomment line below to get no match, will contain device
+    // udev_enumerate_add_nomatch_sysattr(enumerator, "path", path);
+
+    // Uncomment line below to get match, will be empty
+    udev_enumerate_add_match_sysattr(enumerator, "path", path);
+
+    printf("Printing devices...\n");
+    res = udev_enumerate_scan_devices(enumerator);
+    if (res < 0) {
+        return res;
+    }
+
+    entry = udev_enumerate_get_list_entry(enumerator);
+    while (entry) {
+        name = udev_list_entry_get_name(entry);
+        printf("%s\n", name);
+        entry = udev_list_entry_get_next(entry);
+    }
+
+    path = udev_device_get_sysattr_value(device, "path");
+    printf("path after: %s\n", path);
+
+    return 0;
+}

--- a/src/pyudev/core.py
+++ b/src/pyudev/core.py
@@ -253,9 +253,8 @@ class Enumerator(object):
 
         Return the instance again.
         """
-        match = (self._libudev.udev_enumerate_add_match_subsystem
-                 if not nomatch else
-                 self._libudev.udev_enumerate_add_nomatch_subsystem)
+        match = self._libudev.udev_enumerate_add_nomatch_subsystem \
+           if nomatch else self._libudev.udev_enumerate_add_match_subsystem
         match(self, ensure_byte_string(subsystem))
         return self
 

--- a/src/pyudev/device/_device.py
+++ b/src/pyudev/device/_device.py
@@ -907,17 +907,32 @@ class Device(Mapping):
 
         Return a generator yielding the names of all properties of this
         device as unicode strings.
+
+        .. deprecated:: 0.21
+           Will be removed in 1.0. Access properties with Device.properties.
         """
-        properties = self._libudev.udev_device_get_properties_list_entry(self)
-        for name, _ in udev_list_iterate(self._libudev, properties):
-            yield ensure_unicode_string(name)
+        import warnings
+        warnings.warn(
+           'Will be removed in 1.0. Access properties with Device.properties.',
+           DeprecationWarning,
+           stacklevel=2
+        )
+        return self.properties.__iter__()
 
     def __len__(self):
         """
         Return the amount of properties defined for this device as integer.
+
+        .. deprecated:: 0.21
+           Will be removed in 1.0. Access properties with Device.properties.
         """
-        properties = self._libudev.udev_device_get_properties_list_entry(self)
-        return sum(1 for _ in udev_list_iterate(self._libudev, properties))
+        import warnings
+        warnings.warn(
+           'Will be removed in 1.0. Access properties with Device.properties.',
+           DeprecationWarning,
+           stacklevel=2
+        )
+        return self.properties.__len__()
 
     def __getitem__(self, prop):
         """
@@ -929,12 +944,17 @@ class Device(Mapping):
         Return the property value as unicode string, or raise a
         :exc:`~exceptions.KeyError`, if the given property is not defined
         for this device.
+
+        .. deprecated:: 0.21
+           Will be removed in 1.0. Access properties with Device.properties.
         """
-        value = self._libudev.udev_device_get_property_value(
-            self, ensure_byte_string(prop))
-        if value is None:
-            raise KeyError(prop)
-        return ensure_unicode_string(value)
+        import warnings
+        warnings.warn(
+           'Will be removed in 1.0. Access properties with Device.properties.',
+           DeprecationWarning,
+           stacklevel=2
+        )
+        return self.properties.__getitem__(prop)
 
     def asint(self, prop):
         """
@@ -947,8 +967,17 @@ class Device(Mapping):
         :exc:`~exceptions.KeyError`, if the given property is not defined
         for this device, or a :exc:`~exceptions.ValueError`, if the property
         value cannot be converted to an integer.
+
+        .. deprecated:: 0.21
+           Will be removed in 1.0. Use Device.properties.asint() instead.
         """
-        return int(self[prop])
+        import warnings
+        warnings.warn(
+           'Will be removed in 1.0. Use Device.properties.asint instead.',
+           DeprecationWarning,
+           stacklevel=2
+        )
+        return self.properties.asint(prop)
 
     def asbool(self, prop):
         """
@@ -965,8 +994,17 @@ class Device(Mapping):
         the property value is ``'0'``.  Any other value raises a
         :exc:`~exceptions.ValueError`.  Raise a :exc:`~exceptions.KeyError`,
         if the given property is not defined for this device.
+
+        .. deprecated:: 0.21
+           Will be removed in 1.0. Use Device.properties.asbool() instead.
         """
-        return string_to_bool(self[prop])
+        import warnings
+        warnings.warn(
+           'Will be removed in 1.0. Use Device.properties.asbool instead.',
+           DeprecationWarning,
+           stacklevel=2
+        )
+        return self.properties.asbool(prop)
 
     def __hash__(self):
         return hash(self.device_path)

--- a/tests/_constants.py
+++ b/tests/_constants.py
@@ -52,13 +52,3 @@ def _UDEV_TEST(version, node=None): # pylint: disable=invalid-name
        _UDEV_VERSION < version,
        reason=fmt_str % (node, version, _UDEV_VERSION)
     )
-
-_VOLATILE_ATTRIBUTES = ('energy_uj', 'power_on_acct')
-def non_volatile_attributes(attributes):
-    """
-    Yields keys for non-volatile attributes only.
-
-    :param dict attributes: attributes dict obtained from udev
-    """
-    return ((k, v) for (k, v) in attributes.items() \
-       if k not in _VOLATILE_ATTRIBUTES)

--- a/tests/_constants.py
+++ b/tests/_constants.py
@@ -72,6 +72,16 @@ _ATTRIBUTE_STRATEGY = \
       )
    )
 
+# the tags object for a given device
+_TAGS_STRATEGY = \
+   strategies.sampled_from(_CONTEXT.list_devices()).map(lambda d: d.tags)
+
+# an arbitrary tag belonging to a given device
+_TAG_STRATEGY = \
+        _TAGS_STRATEGY.filter(lambda t: sum(1 for _ in t) != 0).flatmap(
+           strategies.sampled_from
+        )
+
 def _UDEV_TEST(version, node=None): # pylint: disable=invalid-name
     fmt_str = "%s: udev version must be at least %s, is %s"
     return pytest.mark.skipif(

--- a/tests/_constants.py
+++ b/tests/_constants.py
@@ -73,6 +73,9 @@ _PROPERTY_STRATEGY = _DEVICE_STRATEGY.flatmap(
    lambda d: strategies.sampled_from(d.properties.items())
 )
 
+_MATCH_PROPERTY_STRATEGY = \
+   _PROPERTY_STRATEGY.filter(lambda p: p[0][-4:] != "_ENC")
+
 # the attributes object for a given device
 _ATTRIBUTES_STRATEGY = _DEVICE_STRATEGY.map(lambda d: d.attributes)
 

--- a/tests/_constants.py
+++ b/tests/_constants.py
@@ -78,6 +78,10 @@ if _UDEV_VERSION <= 222:
     _ATTRIBUTE_STRATEGY = \
        _ATTRIBUTE_STRATEGY.filter(lambda p: not p[1].startswith(b"\\"))
 
+if _UDEV_VERSION <= 222:
+    _ATTRIBUTE_STRATEGY = \
+       _ATTRIBUTE_STRATEGY.filter(lambda p: not p[1][-1:] == b" ")
+
 # the tags object for a given device
 _TAGS_STRATEGY = \
    strategies.sampled_from(_CONTEXT.list_devices()).map(lambda d: d.tags)

--- a/tests/_constants.py
+++ b/tests/_constants.py
@@ -49,6 +49,9 @@ _UDEV_VERSION = int(udev.UDevAdm.adm().query_udev_version())
 _SUBSYSTEM_STRATEGY = \
    strategies.sampled_from(_CONTEXT.list_devices()).map(lambda x: x.subsystem)
 
+_SYSNAME_STRATEGY = \
+   strategies.sampled_from(_CONTEXT.list_devices()).map(lambda x: x.sys_name)
+
 def _UDEV_TEST(version, node=None): # pylint: disable=invalid-name
     fmt_str = "%s: udev version must be at least %s, is %s"
     return pytest.mark.skipif(

--- a/tests/_constants.py
+++ b/tests/_constants.py
@@ -52,6 +52,11 @@ _SUBSYSTEM_STRATEGY = \
 _SYSNAME_STRATEGY = \
    strategies.sampled_from(_CONTEXT.list_devices()).map(lambda x: x.sys_name)
 
+_PROPERTY_STRATEGY = \
+   strategies.sampled_from(_CONTEXT.list_devices()).flatmap(
+      lambda d: strategies.sampled_from(d.properties.items())
+   )
+
 def _UDEV_TEST(version, node=None): # pylint: disable=invalid-name
     fmt_str = "%s: udev version must be at least %s, is %s"
     return pytest.mark.skipif(

--- a/tests/_constants.py
+++ b/tests/_constants.py
@@ -60,6 +60,18 @@ _PROPERTY_STRATEGY = \
       lambda d: strategies.sampled_from(d.properties.items())
    )
 
+# the attributes object for a given device
+_ATTRIBUTES_STRATEGY = \
+   strategies.sampled_from(_CONTEXT.list_devices()).map(lambda d: d.attributes)
+
+# an attribute key and value pair
+_ATTRIBUTE_STRATEGY = \
+   _ATTRIBUTES_STRATEGY.flatmap(
+      lambda attrs: strategies.sampled_from(attrs.available_attributes).map(
+         lambda key: (key, attrs.get(key))
+      )
+   )
+
 def _UDEV_TEST(version, node=None): # pylint: disable=invalid-name
     fmt_str = "%s: udev version must be at least %s, is %s"
     return pytest.mark.skipif(

--- a/tests/_constants.py
+++ b/tests/_constants.py
@@ -49,6 +49,9 @@ _UDEV_VERSION = int(udev.UDevAdm.adm().query_udev_version())
 _SUBSYSTEM_STRATEGY = \
    strategies.sampled_from(_CONTEXT.list_devices()).map(lambda x: x.subsystem)
 
+# Workaround for issue #181
+_SUBSYSTEM_STRATEGY = _SUBSYSTEM_STRATEGY.filter(lambda s: s != 'i2c')
+
 _SYSNAME_STRATEGY = \
    strategies.sampled_from(_CONTEXT.list_devices()).map(lambda x: x.sys_name)
 

--- a/tests/_constants.py
+++ b/tests/_constants.py
@@ -46,6 +46,9 @@ _CONTEXT_STRATEGY = strategies.just(_CONTEXT)
 
 _UDEV_VERSION = int(udev.UDevAdm.adm().query_udev_version())
 
+_SUBSYSTEM_STRATEGY = \
+   strategies.sampled_from(_CONTEXT.list_devices()).map(lambda x: x.subsystem)
+
 def _UDEV_TEST(version, node=None): # pylint: disable=invalid-name
     fmt_str = "%s: udev version must be at least %s, is %s"
     return pytest.mark.skipif(

--- a/tests/_constants.py
+++ b/tests/_constants.py
@@ -91,11 +91,10 @@ _ATTRIBUTE_STRATEGY = _ATTRIBUTE_STRATEGY.filter(lambda p: p[1] is not None)
 
 if _UDEV_VERSION <= 222:
     _ATTRIBUTE_STRATEGY = \
-       _ATTRIBUTE_STRATEGY.filter(lambda p: not p[1].startswith(b"\\"))
-
-if _UDEV_VERSION <= 222:
-    _ATTRIBUTE_STRATEGY = \
-       _ATTRIBUTE_STRATEGY.filter(lambda p: not p[1][-1:] == b" ")
+       _ATTRIBUTE_STRATEGY.filter(
+          lambda p: not p[1].startswith(b"\\") and not p[1][-1:] == b" " and \
+          not p[1].startswith(b'[')
+       )
 
 # the tags object for a given device
 _TAGS_STRATEGY = _DEVICE_STRATEGY.map(lambda d: d.tags)

--- a/tests/_constants.py
+++ b/tests/_constants.py
@@ -72,6 +72,12 @@ _ATTRIBUTE_STRATEGY = \
       )
    )
 
+_ATTRIBUTE_STRATEGY = _ATTRIBUTE_STRATEGY.filter(lambda p: p[1] is not None)
+
+if _UDEV_VERSION <= 222:
+    _ATTRIBUTE_STRATEGY = \
+       _ATTRIBUTE_STRATEGY.filter(lambda p: not p[1].startswith(b"\\"))
+
 # the tags object for a given device
 _TAGS_STRATEGY = \
    strategies.sampled_from(_CONTEXT.list_devices()).map(lambda d: d.tags)

--- a/tests/_device_tests/_device_tests.py
+++ b/tests/_device_tests/_device_tests.py
@@ -340,12 +340,19 @@ class TestDevice(object):
     @settings(max_examples=100)
     @_UDEV_TEST(230, "check exact equivalence of device_datum and device")
     def test_length(self, a_context, device_datum):
+        """
+        Verify that the keys in the device and in the datum are equal.
+        """
         device = Devices.from_path(a_context, device_datum.device_path)
-        assert len(device) == len(device_datum.properties)
+        assert frozenset(device_datum.properties.keys()) == \
+           frozenset(device.keys())
 
     @given(_CONTEXT_STRATEGY, strategies.sampled_from(_DEVICE_DATA))
     @settings(max_examples=100)
     def test_key_subset(self, a_context, device_datum):
+        """
+        Verify that the device contains all the keys in the device datum.
+        """
         device = Devices.from_path(a_context, device_datum.device_path)
         assert frozenset(device_datum.properties.keys()) <= \
            frozenset(device.keys())

--- a/tests/_device_tests/_tags_tests.py
+++ b/tests/_device_tests/_tags_tests.py
@@ -70,8 +70,7 @@ class TestTags(object):
     @settings(max_examples=5, min_satisfying_examples=1)
     def test_contains(self, a_context, device_datum):
         device = Device.from_path(a_context, device_datum.device_path)
-        for tag in device_datum.tags:
-            assert tag in device.tags
+        assert frozenset(device_datum.tags) == frozenset(device.tags)
 
     @given(strategies.sampled_from(_DEVICES))
     @settings(max_examples=5)

--- a/tests/_device_tests/_tags_tests.py
+++ b/tests/_device_tests/_tags_tests.py
@@ -56,21 +56,13 @@ class TestTags(object):
     )
     @given(_CONTEXT_STRATEGY, strategies.sampled_from(_device_data))
     @settings(max_examples=5, min_satisfying_examples=1)
-    def test_iteration(self, a_context, device_datum):
+    def test_iteration_and_contains(self, a_context, device_datum):
+        """
+        Test that iteration yields all tags and contains checks them.
+        """
         device = Device.from_path(a_context, device_datum.device_path)
-        assert set(device.tags) == set(device_datum.tags)
-        for tag in device.tags:
-            assert is_unicode_string(tag)
-
-    @pytest.mark.skipif(
-       len(_device_data) == 0,
-       reason="no device with tags"
-    )
-    @given(_CONTEXT_STRATEGY, strategies.sampled_from(_device_data))
-    @settings(max_examples=5, min_satisfying_examples=1)
-    def test_contains(self, a_context, device_datum):
-        device = Device.from_path(a_context, device_datum.device_path)
-        assert frozenset(device_datum.tags) == frozenset(device.tags)
+        assert frozenset(device.tags) == frozenset(device_datum.tags)
+        assert all(is_unicode_string(tag) for tag in device.tags)
 
     @given(strategies.sampled_from(_DEVICES))
     @settings(max_examples=5)

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -180,6 +180,9 @@ class TestEnumerator(object):
         Test that nomatch returns no devices with attribute value match.
         """
         key, value = pair
+        if _UDEV_VERSION <= 222:
+            assume(not value.startswith(b"\\"))
+
         devices = list(
            context.list_devices().match_attribute(key, value, nomatch=True)
         )

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -31,6 +31,7 @@ from pyudev import Enumerator
 from ._constants import _CONTEXT_STRATEGY
 from ._constants import _DEVICES
 from ._constants import _SUBSYSTEM_STRATEGY
+from ._constants import _SYSNAME_STRATEGY
 from ._constants import _UDEV_TEST
 from ._constants import _UDEV_VERSION
 
@@ -98,10 +99,14 @@ class TestEnumerator(object):
         devices = set(context.list_devices())
         assert devices == m_devices.union(nm_devices)
 
-    def test_match_sys_name(self, context):
-        devices = context.list_devices().match_sys_name('sda')
-        for device in devices:
-            assert device.sys_name == 'sda'
+    @given(_CONTEXT_STRATEGY, _SYSNAME_STRATEGY)
+    @settings(max_examples=5)
+    def test_match_sys_name(self, context, sysname):
+        """
+        A sysname lookup only gives devices with that sysname.
+        """
+        devices = context.list_devices().match_sys_name(sysname)
+        assert all(device.sys_name == sysname for device in devices)
 
     def test_match_property_string(self, context):
         devices = list(context.list_devices().match_property('DRIVER', 'usb'))

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -27,7 +27,6 @@ from hypothesis import given
 from hypothesis import note
 from hypothesis import settings
 from hypothesis import strategies
-from hypothesis import HealthCheck
 
 from pyudev import Enumerator
 
@@ -40,6 +39,8 @@ from ._constants import _SYSNAME_STRATEGY
 from ._constants import _TAG_STRATEGY
 from ._constants import _UDEV_TEST
 from ._constants import _UDEV_VERSION
+
+from .utils import failed_health_check_wrapper
 
 
 @pytest.fixture
@@ -66,6 +67,7 @@ class TestEnumerator(object):
     Test the Enumerator class.
     """
 
+    @failed_health_check_wrapper
     @given(_CONTEXT_STRATEGY, _SUBSYSTEM_STRATEGY)
     @settings(max_examples=5)
     def test_match_subsystem(self, context, subsystem):
@@ -75,6 +77,7 @@ class TestEnumerator(object):
         devices = context.list_devices().match_subsystem(subsystem)
         assert all(device.subsystem == subsystem for device in devices)
 
+    @failed_health_check_wrapper
     @given(_CONTEXT_STRATEGY, _SUBSYSTEM_STRATEGY)
     @settings(max_examples=5)
     def test_match_subsystem_nomatch(self, context, subsystem):
@@ -86,6 +89,7 @@ class TestEnumerator(object):
         assert all(d.subsystem is not None and d.subsystem != subsystem \
            for d in devices)
 
+    @failed_health_check_wrapper
     @given(_CONTEXT_STRATEGY, _SUBSYSTEM_STRATEGY)
     @settings(max_examples=5)
     def test_match_subsystem_nomatch_unfulfillable(self, context, subsystem):
@@ -97,6 +101,7 @@ class TestEnumerator(object):
         devices.match_subsystem(subsystem, nomatch=True)
         assert not list(devices)
 
+    @failed_health_check_wrapper
     @given(_CONTEXT_STRATEGY, _SUBSYSTEM_STRATEGY)
     @settings(max_examples=5)
     def test_match_subsystem_nomatch_complete(self, context, subsystem):
@@ -117,6 +122,7 @@ class TestEnumerator(object):
         devices = set(context.list_devices())
         assert devices == m_devices.union(nm_devices)
 
+    @failed_health_check_wrapper
     @given(_CONTEXT_STRATEGY, _SYSNAME_STRATEGY)
     @settings(max_examples=5)
     def test_match_sys_name(self, context, sysname):
@@ -126,6 +132,7 @@ class TestEnumerator(object):
         devices = context.list_devices().match_sys_name(sysname)
         assert all(device.sys_name == sysname for device in devices)
 
+    @failed_health_check_wrapper
     @given(_CONTEXT_STRATEGY, _PROPERTY_STRATEGY)
     @settings(max_examples=50)
     def test_match_property_string(self, context, pair):
@@ -136,6 +143,7 @@ class TestEnumerator(object):
         devices = context.list_devices().match_property(key, value)
         assert all(device.properties[key] == value for device in devices)
 
+    @failed_health_check_wrapper
     @given(
        _CONTEXT_STRATEGY,
        _PROPERTY_STRATEGY.filter(lambda x: _is_int(x[1]))
@@ -151,14 +159,12 @@ class TestEnumerator(object):
         assert all(device[key] == value and device.asint(key) == int(value) \
            for device in devices)
 
+    @failed_health_check_wrapper
     @given(
        _CONTEXT_STRATEGY,
        _PROPERTY_STRATEGY.filter(lambda x: _is_bool(x[1]))
     )
-    @settings(
-       max_examples=10,
-       suppress_health_check=[HealthCheck.filter_too_much, HealthCheck.too_slow]
-    )
+    @settings(max_examples=10)
     def test_match_property_bool(self, context, pair):
         """
         Verify that a probably boolean property lookup works.
@@ -172,6 +178,7 @@ class TestEnumerator(object):
            for device in devices
         )
 
+    @failed_health_check_wrapper
     @given(
        _CONTEXT_STRATEGY,
        _ATTRIBUTE_STRATEGY.filter(lambda p: p[1] is not None)
@@ -197,14 +204,12 @@ class TestEnumerator(object):
            )
         )
 
+    @failed_health_check_wrapper
     @given(
        _CONTEXT_STRATEGY,
        _ATTRIBUTE_STRATEGY.filter(lambda p: p[1] is not None)
     )
-    @settings(
-       max_examples=10,
-       suppress_health_check=[HealthCheck.filter_too_much, HealthCheck.too_slow]
-    )
+    @settings(max_examples=10)
     def test_match_attribute_backslash(self, context, pair):
         """
         Test that no matches with value starting with a backslash work.
@@ -224,6 +229,7 @@ class TestEnumerator(object):
         )
         assert any(device.attributes.get(key) == value for device in devices)
 
+    @failed_health_check_wrapper
     @given(
        _CONTEXT_STRATEGY,
        _ATTRIBUTE_STRATEGY.filter(lambda p: p[1] is not None)
@@ -239,6 +245,7 @@ class TestEnumerator(object):
         devices.match_attribute(key, value, nomatch=True)
         assert not list(devices)
 
+    @failed_health_check_wrapper
     @given(
        _CONTEXT_STRATEGY,
        _ATTRIBUTE_STRATEGY.filter(lambda p: p[1] is not None)
@@ -262,6 +269,7 @@ class TestEnumerator(object):
         devices = frozenset(context.list_devices())
         assert devices == m_devices.union(nm_devices)
 
+    @failed_health_check_wrapper
     @given(
        _CONTEXT_STRATEGY,
        _ATTRIBUTE_STRATEGY.filter(lambda p: p[1] is not None)
@@ -275,6 +283,7 @@ class TestEnumerator(object):
         devices = context.list_devices().match_attribute(key, value)
         assert all(device.attributes.get(key) == value for device in devices)
 
+    @failed_health_check_wrapper
     @given(
        _CONTEXT_STRATEGY,
        _ATTRIBUTE_STRATEGY.filter(lambda x: _is_int(x[1]))
@@ -292,6 +301,7 @@ class TestEnumerator(object):
             assert attributes.get(key) == value
             assert device.attributes.asint(key) == int_value
 
+    @failed_health_check_wrapper
     @given(
        _CONTEXT_STRATEGY,
        _ATTRIBUTE_STRATEGY.filter(lambda x: _is_bool(x[1]))
@@ -310,6 +320,7 @@ class TestEnumerator(object):
             assert attributes.asbool(key) == bool_value
 
     @_UDEV_TEST(154, "test_match_tag")
+    @failed_health_check_wrapper
     @given(_CONTEXT_STRATEGY, _TAG_STRATEGY)
     @settings(max_examples=50)
     def test_match_tag(self, context, tag):

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -61,13 +61,19 @@ class TestEnumerator(object):
 
     @failed_health_check_wrapper
     @given(_CONTEXT_STRATEGY, _SUBSYSTEM_STRATEGY)
-    @settings(max_examples=5)
+    @settings(max_examples=50)
     def test_match_subsystem(self, context, subsystem):
         """
         Subsystem match matches devices w/ correct subsystem.
         """
-        devices = context.list_devices().match_subsystem(subsystem)
+        devices = frozenset(context.list_devices().match_subsystem(subsystem))
         assert all(device.subsystem == subsystem for device in devices)
+
+        all_devices = frozenset(context.list_devices())
+
+        complement = all_devices - devices
+
+        assert all(device.subsystem != subsystem for device in complement)
 
     @failed_health_check_wrapper
     @given(_CONTEXT_STRATEGY, _SUBSYSTEM_STRATEGY)
@@ -76,10 +82,16 @@ class TestEnumerator(object):
         """
         Subsystem no match gets no subsystem with subsystem.
         """
-        devices = \
+        devices = frozenset(
            context.list_devices().match_subsystem(subsystem, nomatch=True)
-        assert all(d.subsystem is not None and d.subsystem != subsystem \
-           for d in devices)
+        )
+        assert all(d.subsystem != subsystem for d in devices)
+
+        all_devices = frozenset(context.list_devices())
+
+        complement = all_devices - devices
+
+        assert all(d.subsystem == subsystem for d in complement)
 
     @failed_health_check_wrapper
     @given(_CONTEXT_STRATEGY, _SUBSYSTEM_STRATEGY)
@@ -121,8 +133,11 @@ class TestEnumerator(object):
         """
         A sysname lookup only gives devices with that sysname.
         """
-        devices = context.list_devices().match_sys_name(sysname)
+        devices = frozenset(context.list_devices().match_sys_name(sysname))
         assert all(device.sys_name == sysname for device in devices)
+        all_devices = frozenset(context.list_devices())
+        complement = all_devices - devices
+        assert all(device.sys_name != sysname for device in complement)
 
     @failed_health_check_wrapper
     @given(_CONTEXT_STRATEGY, _PROPERTY_STRATEGY)
@@ -132,8 +147,11 @@ class TestEnumerator(object):
         Match property only gets devices with that property.
         """
         key, value = pair
-        devices = context.list_devices().match_property(key, value)
+        devices = frozenset(context.list_devices().match_property(key, value))
         assert all(device.properties[key] == value for device in devices)
+        all_devices = frozenset(context.list_devices())
+        complement = all_devices - devices
+        assert all(device.properties[key] != value for device in complement)
 
     @failed_health_check_wrapper
     @given(
@@ -178,13 +196,18 @@ class TestEnumerator(object):
         """
         key, value = pair
 
-        devices = \
+        devices = frozenset(
            context.list_devices().match_attribute(key, value, nomatch=True)
+        )
 
         counter_examples = \
            [device for device in devices if device.attributes.get(key) == value]
 
         assert counter_examples == []
+
+        all_devices = frozenset(context.list_devices())
+        complement = all_devices - devices
+        assert all(device.attributes.get(key) == value for device in complement)
 
     @failed_health_check_wrapper
     @given(_CONTEXT_STRATEGY, _ATTRIBUTE_STRATEGY)
@@ -275,8 +298,13 @@ class TestEnumerator(object):
         """
         Test that matches returned for tag actually have tag.
         """
-        devices = context.list_devices().match_tag(tag)
+        devices = frozenset(context.list_devices().match_tag(tag))
         assert all(tag in device.tags for device in devices)
+
+        all_devices = frozenset(context.list_devices())
+        complement = all_devices - devices
+
+        assert all(tag not in device.tags for device in complement)
 
     @failed_health_check_wrapper
     @given(

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -261,10 +261,18 @@ class TestEnumerator(object):
         devices = frozenset(context.list_devices())
         assert devices == m_devices.union(nm_devices)
 
-    def test_match_attribute_string(self, context):
-        devices = list(context.list_devices().match_attribute('driver', 'usb'))
-        for device in devices:
-            assert device.attributes.get('driver') == b'usb'
+    @given(
+       _CONTEXT_STRATEGY,
+       _ATTRIBUTE_STRATEGY.filter(lambda p: p[1] is not None)
+    )
+    @settings(max_examples=50)
+    def test_match_attribute_string(self, context, pair):
+        """
+        Test that matching attribute as string works.
+        """
+        key, value = pair
+        devices = context.list_devices().match_attribute(key, value)
+        assert all(device.attributes.get(key) == value for device in devices)
 
     def test_match_attribute_int(self, context):
         # busnum gives us the number of a USB bus.  And any decent system

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -274,17 +274,22 @@ class TestEnumerator(object):
         devices = context.list_devices().match_attribute(key, value)
         assert all(device.attributes.get(key) == value for device in devices)
 
-    def test_match_attribute_int(self, context):
-        # busnum gives us the number of a USB bus.  And any decent system
-        # likely has two or more usb buses, so this should work on more or less
-        # any system.  I didn't find any other attribute that is likely to be
-        # present on a wide range of system, so this is probably as general as
-        # possible.  Still it may fail because the attribute isn't present on
-        # any device at all on the system running the test
-        devices = list(context.list_devices().match_attribute('busnum', 2))
+    @given(
+       _CONTEXT_STRATEGY,
+       _ATTRIBUTE_STRATEGY.filter(lambda x: _is_int(x[1]))
+    )
+    @settings(max_examples=50)
+    def test_match_attribute_int(self, context, pair):
+        """
+        Test matching integer attribute.
+        """
+        key, value = pair
+        int_value = int(value)
+        devices = context.list_devices().match_attribute(key, int_value)
         for device in devices:
-            assert device.attributes.get('busnum') == b'2'
-            assert device.attributes.asint('busnum') == 2
+            attributes = device.attributes
+            assert attributes.get(key) == value
+            assert device.attributes.asint(key) == int_value
 
     def test_match_attribute_bool(self, context):
         # ro tells us whether a volumne is mounted read-only or not.  And any

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -348,6 +348,12 @@ class TestEnumerator(object):
             else:
                 assert parent not in children
 
+
+class TestEnumeratorMatchCombinations(object):
+    """
+    Test combinations of matches.
+    """
+
     def test_combined_matches_of_same_type(self, context):
         """
         Test for behaviour as observed in #1

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -308,17 +308,6 @@ class TestEnumerator(object):
             assert attributes.get(key) == value
             assert attributes.asbool(key) == bool_value
 
-    @_UDEV_TEST(154, "test_match_tag_mock")
-    def test_match_tag_mock(self, context):
-        enumerator = context.list_devices()
-        funcname = 'udev_enumerate_add_match_tag'
-        spec = lambda e, t: None
-        with mock.patch.object(enumerator._libudev, funcname,
-                               autospec=spec) as func:
-            retval = enumerator.match_tag('spam')
-            assert retval is enumerator
-            func.assert_called_with(enumerator, b'spam')
-
     @_UDEV_TEST(154, "test_match_tag")
     def test_match_tag(self, context):
         devices = list(context.list_devices().match_tag('seat'))
@@ -348,17 +337,6 @@ class TestEnumerator(object):
                 assert parent in children
             else:
                 assert parent not in children
-
-    @_UDEV_TEST(165, "test_match_is_initialized_mock")
-    def test_match_is_initialized_mock(self, context):
-        enumerator = context.list_devices()
-        funcname = 'udev_enumerate_add_match_is_initialized'
-        spec = lambda e: None
-        with mock.patch.object(enumerator._libudev, funcname,
-                               autospec=spec) as func:
-            retval = enumerator.match_is_initialized()
-            assert retval is enumerator
-            func.assert_called_with(enumerator)
 
     def test_combined_matches_of_same_type(self, context):
         """

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -22,6 +22,7 @@ from __future__ import (print_function, division, unicode_literals,
 import pytest
 import mock
 
+from hypothesis import assume
 from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -587,32 +587,3 @@ class TestEnumeratorMatchMethod(object):
             posargs = [args for args, _ in match_property.call_args_list]
             assert ('spam', mock.sentinel.spam) in posargs
             assert ('eggs', mock.sentinel.eggs) in posargs
-
-
-class TestContext(object):
-
-    @pytest.mark.match
-    def test_list_devices(self, context):
-        devices = list(context.list_devices(
-            subsystem='input', ID_INPUT_MOUSE=True, sys_name='mouse0'))
-        for device in devices:
-            assert device.subsystem == 'input'
-            assert device.asbool('ID_INPUT_MOUSE')
-            assert device.sys_name == 'mouse0'
-
-    @pytest.mark.match
-    def test_list_devices_passthrough(self, context):
-        with mock.patch.object(Enumerator, 'match') as match:
-            context.list_devices(subsystem=mock.sentinel.subsystem,
-                                 sys_name=mock.sentinel.sys_name,
-                                 tag=mock.sentinel.tag,
-                                 parent=mock.sentinel.parent,
-                                 prop1=mock.sentinel.prop1,
-                                 prop2=mock.sentinel.prop2)
-            match.assert_called_with(
-                subsystem=mock.sentinel.subsystem,
-                sys_name=mock.sentinel.sys_name,
-                tag=mock.sentinel.tag,
-                parent=mock.sentinel.parent,
-                prop1=mock.sentinel.prop1,
-                prop2=mock.sentinel.prop2)

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -223,10 +223,19 @@ class TestEnumerator(object):
         )
         assert any(device.attributes.get(key) == value for device in devices)
 
-    def test_match_attribute_nomatch_unfulfillable(self, context):
+    @given(
+       _CONTEXT_STRATEGY,
+       _ATTRIBUTE_STRATEGY.filter(lambda p: p[1] is not None)
+    )
+    @settings(max_examples=50)
+    def test_match_attribute_nomatch_unfulfillable(self, context, pair):
+        """
+        Match and no match for a key/value gives empty set.
+        """
+        key, value = pair
         devices = context.list_devices()
-        devices.match_attribute('driver', 'usb')
-        devices.match_attribute('driver', 'usb', nomatch=True)
+        devices.match_attribute(key, value)
+        devices.match_attribute(key, value, nomatch=True)
         assert not list(devices)
 
     def test_match_attribute_string(self, context):

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -238,6 +238,29 @@ class TestEnumerator(object):
         devices.match_attribute(key, value, nomatch=True)
         assert not list(devices)
 
+    @given(
+       _CONTEXT_STRATEGY,
+       _ATTRIBUTE_STRATEGY.filter(lambda p: p[1] is not None)
+    )
+    @settings(max_examples=50)
+    def test_match_attribute_nomatch_complete(self, context, pair):
+        """
+        Test that w/ respect to the universe of devices returned by
+        list_devices() a match and its inverse are complements of each other.
+        """
+        key, value = pair
+        m_devices = frozenset(
+           context.list_devices().match_attribute(key, value)
+        )
+        nm_devices = frozenset(
+           context.list_devices().match_attribute(key, value, nomatch=True)
+        )
+
+        assert not m_devices.intersection(nm_devices)
+
+        devices = frozenset(context.list_devices())
+        assert devices == m_devices.union(nm_devices)
+
     def test_match_attribute_string(self, context):
         devices = list(context.list_devices().match_attribute('driver', 'usb'))
         for device in devices:

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -98,25 +98,6 @@ class TestEnumerator(object):
         devices = set(context.list_devices())
         assert devices == m_devices.union(nm_devices)
 
-    def test_match_scsi_devices_children(self, context):
-        """
-        Test that every device with type scsi_device has only one disk
-        descendant.
-        """
-        scsi_devices = context.list_devices().match_property(
-           'DEVTYPE',
-           'scsi_device'
-        )
-
-        def func(dev):
-            return context.list_devices(
-               subsystem='block',
-               DEVTYPE='disk',
-               parent=dev
-            )
-
-        assert all(len(list(func(d))) in (0, 1) for d in scsi_devices)
-
     def test_match_sys_name(self, context):
         devices = context.list_devices().match_sys_name('sda')
         for device in devices:

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -42,12 +42,6 @@ from ._constants import _UDEV_VERSION
 
 from .utils import failed_health_check_wrapper
 
-
-@pytest.fixture
-def enumerator(request):
-    context = request.getfuncargvalue('context')
-    return context.list_devices()
-
 def _is_int(value):
     try:
         int(value)
@@ -382,32 +376,68 @@ class TestEnumerator(object):
             assert device.asbool('ID_INPUT_MOUSE')
             assert device.sys_name == 'mouse0'
 
+
+class TestEnumeratorMatchMethod(object):
+    """
+    Test the behavior of Enumerator.match.
+
+    Only methods that test behavior of this method by patching the Enumerator
+    object with the methods that match() should invoke belong here.
+    """
+
+    _ENUMERATOR_STRATEGY = _CONTEXT_STRATEGY.map(lambda x: x.list_devices())
+
+    @given(_ENUMERATOR_STRATEGY)
+    @settings(max_examples=1)
     def test_match_passthrough_subsystem(self, enumerator):
+        """
+        Test that special keyword subsystem results in a match_subsystem call.
+        """
         with mock.patch.object(enumerator, 'match_subsystem',
                                autospec=True) as match_subsystem:
             enumerator.match(subsystem=mock.sentinel.subsystem)
             match_subsystem.assert_called_with(mock.sentinel.subsystem)
 
+    @given(_ENUMERATOR_STRATEGY)
+    @settings(max_examples=1)
     def test_match_passthrough_sys_name(self, enumerator):
+        """
+        Test that special keyword sys_name results in a match_sys_name call.
+        """
         with mock.patch.object(enumerator, 'match_sys_name',
                                autospec=True) as match_sys_name:
             enumerator.match(sys_name=mock.sentinel.sys_name)
             match_sys_name.assert_called_with(mock.sentinel.sys_name)
 
+    @given(_ENUMERATOR_STRATEGY)
+    @settings(max_examples=1)
     def test_match_passthrough_tag(self, enumerator):
+        """
+        Test that special keyword tag results in a match_tag call.
+        """
         with mock.patch.object(enumerator, 'match_tag',
                                autospec=True) as match_tag:
             enumerator.match(tag=mock.sentinel.tag)
             match_tag.assert_called_with(mock.sentinel.tag)
 
     @_UDEV_TEST(172, "test_match_passthrough_parent")
+    @given(_ENUMERATOR_STRATEGY)
+    @settings(max_examples=1)
     def test_match_passthrough_parent(self, enumerator):
+        """
+        Test that special keyword 'parent' results in a match parent call.
+        """
         with mock.patch.object(enumerator, 'match_parent',
                                autospec=True) as match_parent:
             enumerator.match(parent=mock.sentinel.parent)
             match_parent.assert_called_with(mock.sentinel.parent)
 
+    @given(_ENUMERATOR_STRATEGY)
+    @settings(max_examples=1)
     def test_match_passthrough_property(self, enumerator):
+        """
+        Test that non-special keyword args are treated as properties.
+        """
         with mock.patch.object(enumerator, 'match_property',
                                autospec=True) as match_property:
             enumerator.match(eggs=mock.sentinel.eggs, spam=mock.sentinel.spam)

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -30,6 +30,7 @@ from pyudev import Enumerator
 
 from ._constants import _CONTEXT_STRATEGY
 from ._constants import _DEVICES
+from ._constants import _SUBSYSTEM_STRATEGY
 from ._constants import _UDEV_TEST
 from ._constants import _UDEV_VERSION
 
@@ -41,25 +42,44 @@ def enumerator(request):
 
 
 class TestEnumerator(object):
+    """
+    Test the Enumerator class.
+    """
 
-    def test_match_subsystem(self, context):
-        devices = context.list_devices().match_subsystem('input')
-        for device in devices:
-            assert device.subsystem == 'input'
+    @given(_CONTEXT_STRATEGY, _SUBSYSTEM_STRATEGY)
+    @settings(max_examples=5)
+    def test_match_subsystem(self, context, subsystem):
+        """
+        Subsystem match matches devices w/ correct subsystem.
+        """
+        devices = context.list_devices().match_subsystem(subsystem)
+        assert all(device.subsystem == subsystem for device in devices)
 
-    def test_match_subsystem_nomatch(self, context):
-        devices = context.list_devices().match_subsystem('input', nomatch=True)
-        for device in devices:
-            assert device.subsystem is not None
-            assert device.subsystem != 'input'
+    @given(_CONTEXT_STRATEGY, _SUBSYSTEM_STRATEGY)
+    @settings(max_examples=5)
+    def test_match_subsystem_nomatch(self, context, subsystem):
+        """
+        Subsystem no match gets no subsystem with subsystem.
+        """
+        devices = \
+           context.list_devices().match_subsystem(subsystem, nomatch=True)
+        assert all(d.subsystem is not None and d.subsystem != subsystem \
+           for d in devices)
 
-    def test_match_subsystem_nomatch_unfulfillable(self, context):
+    @given(_CONTEXT_STRATEGY, _SUBSYSTEM_STRATEGY)
+    @settings(max_examples=5)
+    def test_match_subsystem_nomatch_unfulfillable(self, context, subsystem):
+        """
+        Combining match and no match should give an empty result.
+        """
         devices = context.list_devices()
-        devices.match_subsystem('input')
-        devices.match_subsystem('input', nomatch=True)
+        devices.match_subsystem(subsystem)
+        devices.match_subsystem(subsystem, nomatch=True)
         assert not list(devices)
 
-    def test_match_subsystem_nomatch_complete(self, context):
+    @given(_CONTEXT_STRATEGY, _SUBSYSTEM_STRATEGY)
+    @settings(max_examples=5)
+    def test_match_subsystem_nomatch_complete(self, context, subsystem):
         """
         Test that w/ respect to the universe of devices returned by
         list_devices() a match and its inverse are complements of each other.
@@ -68,9 +88,9 @@ class TestEnumerator(object):
         so with respect to the whole universe of devices, the two are
         not complements of each other.
         """
-        m_devices = set(context.list_devices().match_subsystem('j'))
+        m_devices = set(context.list_devices().match_subsystem(subsystem))
         nm_devices = set(
-           context.list_devices().match_subsystem('j', nomatch=True)
+           context.list_devices().match_subsystem(subsystem, nomatch=True)
         )
 
         assert not m_devices.intersection(nm_devices)

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -196,11 +196,12 @@ class TestEnumerator(object):
         """
         key, value = pair
 
+        all_devices = frozenset(context.list_devices())
         devices = frozenset(context.list_devices().match_attribute(key, value))
         assert all(d.attributes.get(key) == value for d in devices)
-        all_devices = frozenset(context.list_devices())
         complement = all_devices - devices
-        assert all(device.attributes.get(key) != value for device in complement)
+        examples = [d for d in complement if d.attributes.get(key) == value]
+        assert examples == []
 
     @failed_health_check_wrapper
     @given(_CONTEXT_STRATEGY, _ATTRIBUTE_STRATEGY)

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -353,6 +353,48 @@ class TestEnumeratorMatchCombinations(object):
     @given(
        _CONTEXT_STRATEGY,
        strategies.lists(
+          elements=_ATTRIBUTE_STRATEGY,
+          min_size=2,
+          max_size=3,
+          unique_by=lambda p: p[0]
+       )
+    )
+    @settings(max_examples=20)
+    def test_combined_attribute_matches(self, context, apairs):
+        """
+        Test for conjunction of attributes.
+
+        If matching multiple attributes, then the result is the intersection of
+        the matching sets, i.e., the resulting filter is a conjunction.
+        """
+        enumeration = context.list_devices()
+
+        all_devices = frozenset(enumeration)
+
+        enumeration = context.list_devices()
+
+        for key, value in apairs:
+            enumeration.match_attribute(key, value)
+
+        devices = list(frozenset(enumeration))
+
+        assert all(
+           all(d.attributes.get(key) == value for key, value in apairs) \
+              for d in devices
+        )
+
+        complement = list(all_devices - frozenset(devices))
+
+        counter_examples = [
+           d for d in complement if \
+           all(d.attributes.get(key) == value for key, value in apairs)
+        ]
+
+        assert counter_examples == []
+
+    @given(
+       _CONTEXT_STRATEGY,
+       strategies.lists(
           elements=_PROPERTY_STRATEGY,
           min_size=1,
           max_size=2,

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -291,14 +291,22 @@ class TestEnumerator(object):
             assert attributes.get(key) == value
             assert device.attributes.asint(key) == int_value
 
-    def test_match_attribute_bool(self, context):
-        # ro tells us whether a volumne is mounted read-only or not.  And any
-        # developers system should have at least one readable volume, thus this
-        # test should work on all systems these tests are ever run on
-        devices = list(context.list_devices().match_attribute('ro', False))
+    @given(
+       _CONTEXT_STRATEGY,
+       _ATTRIBUTE_STRATEGY.filter(lambda x: _is_bool(x[1]))
+    )
+    @settings(max_examples=50)
+    def test_match_attribute_bool(self, context, pair):
+        """
+        Test matching boolean attribute.
+        """
+        key, value = pair
+        bool_value = True if int(value) == 1 else False
+        devices = context.list_devices().match_attribute(key, bool_value)
         for device in devices:
-            assert device.attributes.get('ro') == b'0'
-            assert not device.attributes.asbool('ro')
+            attributes = device.attributes
+            assert attributes.get(key) == value
+            assert attributes.asbool(key) == bool_value
 
     @_UDEV_TEST(154, "test_match_tag_mock")
     def test_match_tag_mock(self, context):

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -30,6 +30,7 @@ from pyudev import Enumerator
 
 from ._constants import _CONTEXT_STRATEGY
 from ._constants import _DEVICES
+from ._constants import _PROPERTY_STRATEGY
 from ._constants import _SUBSYSTEM_STRATEGY
 from ._constants import _SYSNAME_STRATEGY
 from ._constants import _UDEV_TEST
@@ -108,11 +109,15 @@ class TestEnumerator(object):
         devices = context.list_devices().match_sys_name(sysname)
         assert all(device.sys_name == sysname for device in devices)
 
-    def test_match_property_string(self, context):
-        devices = list(context.list_devices().match_property('DRIVER', 'usb'))
-        for device in devices:
-            assert device['DRIVER'] == 'usb'
-            assert device.driver == 'usb'
+    @given(_CONTEXT_STRATEGY, _PROPERTY_STRATEGY)
+    @settings(max_examples=50)
+    def test_match_property_string(self, context, pair):
+        """
+        Match property only gets devices with that property.
+        """
+        key, value = pair
+        devices = context.list_devices().match_property(key, value)
+        assert all(device.properties[key] == value for device in devices)
 
     def test_match_property_int(self, context):
         devices = list(context.list_devices().match_property(

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -31,7 +31,7 @@ from pyudev import Enumerator
 from ._constants import _ATTRIBUTE_STRATEGY
 from ._constants import _CONTEXT_STRATEGY
 from ._constants import _DEVICE_STRATEGY
-from ._constants import _PROPERTY_STRATEGY
+from ._constants import _MATCH_PROPERTY_STRATEGY
 from ._constants import _SUBSYSTEM_STRATEGY
 from ._constants import _SYSNAME_STRATEGY
 from ._constants import _TAG_STRATEGY
@@ -140,7 +140,7 @@ class TestEnumerator(object):
         assert all(device.sys_name != sysname for device in complement)
 
     @failed_health_check_wrapper
-    @given(_CONTEXT_STRATEGY, _PROPERTY_STRATEGY)
+    @given(_CONTEXT_STRATEGY, _MATCH_PROPERTY_STRATEGY)
     @settings(max_examples=50)
     def test_match_property_string(self, context, pair):
         """
@@ -156,7 +156,7 @@ class TestEnumerator(object):
     @failed_health_check_wrapper
     @given(
        _CONTEXT_STRATEGY,
-       _PROPERTY_STRATEGY.filter(lambda x: _is_int(x[1]))
+       _MATCH_PROPERTY_STRATEGY.filter(lambda x: _is_int(x[1]))
     )
     @settings(max_examples=50)
     def test_match_property_int(self, context, pair):
@@ -172,7 +172,7 @@ class TestEnumerator(object):
     @failed_health_check_wrapper
     @given(
        _CONTEXT_STRATEGY,
-       _PROPERTY_STRATEGY.filter(lambda x: _is_bool(x[1]))
+       _MATCH_PROPERTY_STRATEGY.filter(lambda x: _is_bool(x[1]))
     )
     @settings(max_examples=10)
     def test_match_property_bool(self, context, pair):
@@ -355,7 +355,7 @@ class TestEnumeratorMatchCombinations(object):
     @given(
        _CONTEXT_STRATEGY,
        strategies.lists(
-          elements=_PROPERTY_STRATEGY,
+          elements=_MATCH_PROPERTY_STRATEGY,
           min_size=2,
           max_size=3,
           unique_by=lambda p: p[0]
@@ -437,7 +437,7 @@ class TestEnumeratorMatchCombinations(object):
     @given(
        _CONTEXT_STRATEGY,
        strategies.lists(
-          elements=_PROPERTY_STRATEGY,
+          elements=_MATCH_PROPERTY_STRATEGY,
           min_size=1,
           max_size=2,
           unique_by=lambda p: p[0]

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -196,6 +196,33 @@ class TestEnumerator(object):
            )
         )
 
+    @given(
+       _CONTEXT_STRATEGY,
+       _ATTRIBUTE_STRATEGY.filter(lambda p: p[1] is not None)
+    )
+    @settings(
+       max_examples=10,
+       suppress_health_check=[HealthCheck.filter_too_much, HealthCheck.too_slow]
+    )
+    def test_match_attribute_backslash(self, context, pair):
+        """
+        Test that no matches with value starting with a backslash work.
+        """
+        key, value = pair
+        assume(value.startswith(b"\\"))
+        devices = context.list_devices().match_attribute(
+           key,
+           value
+        )
+        assert list(devices) == []
+
+        devices = context.list_devices().match_attribute(
+           key,
+           value,
+           nomatch=True
+        )
+        assert any(device.attributes.get(key) == value for device in devices)
+
     def test_match_attribute_nomatch_unfulfillable(self, context):
         devices = context.list_devices()
         devices.match_attribute('driver', 'usb')

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -98,9 +98,8 @@ class TestEnumerator(object):
         not complements of each other.
         """
         m_devices = set(context.list_devices().match_subsystem(subsystem))
-        nm_devices = set(
-           context.list_devices().match_subsystem(subsystem, nomatch=True)
-        )
+        nm_devices = \
+           set(context.list_devices().match_subsystem(subsystem, nomatch=True))
 
         assert not m_devices.intersection(nm_devices)
 

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -512,11 +512,13 @@ class TestEnumeratorMatchCombinations(object):
         all_devices = frozenset(context.list_devices())
         complement = all_devices - devices
 
-        assert all(
-           device.subsystem != subsystem or device.sys_name != sysname or \
-           device.properties.get(prop_name) != prop_value \
-           for device in complement
-        )
+        counter_examples = [
+           device for device in complement if \
+           device.subsystem == subsystem and device.sys_name == sysname and \
+           device.properties.get(prop_name) == prop_value
+        ]
+
+        assert counter_examples == []
 
 
 class TestEnumeratorMatchMethod(object):

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -151,7 +151,7 @@ class TestEnumerator(object):
         assert all(device.properties[key] == value for device in devices)
         all_devices = frozenset(context.list_devices())
         complement = all_devices - devices
-        assert all(device.properties[key] != value for device in complement)
+        assert all(device.properties.get(key) != value for device in complement)
 
     @failed_health_check_wrapper
     @given(
@@ -187,6 +187,20 @@ class TestEnumerator(object):
            device.asbool(key) == bool_value \
            for device in devices
         )
+
+    @failed_health_check_wrapper
+    @given(_CONTEXT_STRATEGY, _ATTRIBUTE_STRATEGY)
+    def test_match_attribute_match(self, context, pair):
+        """
+        Test match returns matching devices.
+        """
+        key, value = pair
+
+        devices = frozenset(context.list_devices().match_attribute(key, value))
+        assert all(d.attributes.get(key) == value for d in devices)
+        all_devices = frozenset(context.list_devices())
+        complement = all_devices - devices
+        assert all(device.attributes.get(key) != value for device in complement)
 
     @failed_health_check_wrapper
     @given(_CONTEXT_STRATEGY, _ATTRIBUTE_STRATEGY)

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -37,6 +37,7 @@ from ._constants import _DEVICES
 from ._constants import _PROPERTY_STRATEGY
 from ._constants import _SUBSYSTEM_STRATEGY
 from ._constants import _SYSNAME_STRATEGY
+from ._constants import _TAG_STRATEGY
 from ._constants import _UDEV_TEST
 from ._constants import _UDEV_VERSION
 
@@ -309,10 +310,14 @@ class TestEnumerator(object):
             assert attributes.asbool(key) == bool_value
 
     @_UDEV_TEST(154, "test_match_tag")
-    def test_match_tag(self, context):
-        devices = list(context.list_devices().match_tag('seat'))
-        for device in devices:
-            assert 'seat' in device.tags
+    @given(_CONTEXT_STRATEGY, _TAG_STRATEGY)
+    @settings(max_examples=50)
+    def test_match_tag(self, context, tag):
+        """
+        Test that matches returned for tag actually have tag.
+        """
+        devices = context.list_devices().match_tag(tag)
+        assert all(tag in device.tags for device in devices)
 
     _devices = [d for d in _DEVICES if d.parent]
     @pytest.mark.skipif(len(_devices) == 0, reason="no device with parent")

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -26,4 +26,5 @@
 
 from . import udev
 
+from .misc import failed_health_check_wrapper
 from .misc import is_unicode_string


### PR DESCRIPTION
Can be reduced to many fewer commits in final release:

The main changes are:
* Deprecate use of device as properties mapping in favor of properties property.
* Small changes to test_attributes.
* Small changes to test_tags.
* Small changes to test_devices.
* Tiny change to one source code method to get rid of double negative.
* Add lots of strategies to test/_constants.py.
* Add way to catch health check and skip in utils.
* Use these things to rewrite test_enumerate.py completely.