### PR TITLE
Debugging info for stack trace

### DIFF
--- a/src/pyudev/_os/poll.py
+++ b/src/pyudev/_os/poll.py
@@ -107,9 +107,15 @@ class Poll(object):
         """
         for fd, event_mask in events:
             if self._has_event(event_mask, select.POLLNVAL):
-                raise IOError('File descriptor not open: {0!r}'.format(fd))
+                print("penguinland says the POLLNVAL fd was {} and the event_mask was {}"
+                      .format(fd, event_mask))
+                continue
+                #raise IOError('File descriptor not open: {0!r}'.format(fd))
             elif self._has_event(event_mask, select.POLLERR):
-                raise IOError('Error while polling fd: {0!r}'.format(fd))
+                print("penguinland says the POLLERR fd was {} and the event_mask was {}"
+                      .format(fd, event_mask))
+                continue
+                #raise IOError('Error while polling fd: {0!r}'.format(fd))
 
             if self._has_event(event_mask, select.POLLIN):
                 yield fd, 'r'

--- a/src/pyudev/monitor.py
+++ b/src/pyudev/monitor.py
@@ -88,6 +88,7 @@ class Monitor(object):
         self._as_parameter_ = monitor_p
         self._libudev = context._libudev
         self._started = False
+        print("penguinland says this monitor's fd is {}".format(self.fileno()))
 
     def __del__(self):
         self._libudev.udev_monitor_unref(self)


### PR DESCRIPTION
Here are the changes I had made to find out that the monitor's POLLERR was set, as described in https://github.com/pyudev/pyudev/issues/194

and here's the relevant output:

```
penguinland@computer$ cat /tmp/program.stdout |grep penguinland|head
penguinland says this monitor's fd is 8
penguinland says the POLLERR fd was 8 and the event_mask was 9
penguinland says the POLLERR fd was 8 and the event_mask was 9
penguinland says the POLLERR fd was 8 and the event_mask was 9
penguinland says the POLLERR fd was 8 and the event_mask was 9
penguinland says the POLLERR fd was 8 and the event_mask was 9
penguinland says the POLLERR fd was 8 and the event_mask was 9
penguinland says the POLLERR fd was 8 and the event_mask was 9
penguinland says the POLLERR fd was 8 and the event_mask was 9
penguinland says the POLLERR fd was 8 and the event_mask was 9
```

I got that line printed out extremely quickly; I think it does that as fast as it can.