### PR TITLE
Change direction of _UDEV_VERSION comparison

### DIFF
--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -316,7 +316,7 @@ class TestEnumerator(object):
         parent = device.parent
         children = list(context.list_devices().match_parent(parent))
         assert device in children
-        if _UDEV_VERSION <= 175:
+        if _UDEV_VERSION >= 175:
             assert parent in children
         else:
             if parent.subsystem is not None:


### PR DESCRIPTION
The parent is in its children, regardless of subsystem, on and after
systemd version 175.

Signed-off-by: mulhern <amulhern@redhat.com>