### PR TITLE
Pin to last pylint 1.* version

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,0 +1,6 @@
+requirements:
+    - pyup_requirements/default.txt:
+        update: all
+        pin: True
+    - pyup_requirements/python2.txt:
+        update: False

--- a/pyup_requirements/default.txt
+++ b/pyup_requirements/default.txt
@@ -1,0 +1,10 @@
+# unit test requirements
+docutils>=0.9
+pytest>=2.8
+mock>=1.0b1
+hypothesis==3.66.1
+
+# documentation requirements
+sphinx>=1.0.7
+
+yapf==0.21.0

--- a/pyup_requirements/python2.txt
+++ b/pyup_requirements/python2.txt
@@ -1,0 +1,3 @@
+# linting
+# Last version of pylint that was Python 2/3 compatible
+pylint==1.9.2

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -40,7 +40,8 @@ README = os.path.join(SOURCE_DIRECTORY, 'README.rst')
 
 # Files in the repository that don't need to be present in the sdist
 REQUIRED_BLACKLIST = [
-    r'^\.git.+', r'\.travis\.yml$', r'^MANIFEST\.in$', r'^Makefile$'
+    r'^\.git.+', r'\.pyup\.yml', r'\.travis\.yml$', r'^MANIFEST\.in$',
+    r'^Makefile$', r'pyup_requirements'
 ]
 
 


### PR DESCRIPTION
pyudev is still Python 2/3, so it is not a good a good idea to move up
to pylint 2.0, which is Python 3 only.

Signed-off-by: mulhern <amulhern@redhat.com>