### PR TITLE
Get rid of six dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,15 +19,15 @@ jobs:
         include:
           # MANDATORY CHECKS USING CURRENT DEVELOPMENT INTERPRETER
           - python-version: 3.9.6
-            dependencies: pytest hypothesis docutils six
+            dependencies: pytest hypothesis docutils
             task: PYTHONPATH=./src make -f Makefile test-travis
           # MANDATORY CHECKS USING LOWEST SUPPORTED INTERPRETER
           - python-version: 3.6.8
-            dependencies: pytest hypothesis docutils six
+            dependencies: pytest hypothesis docutils
             task: PYTHONPATH=./src make -f Makefile test-travis
           # MANDATORY CHECKS USING PYPY INTERPRETER
           - python-version: pypy3
-            dependencies: pytest hypothesis docutils six
+            dependencies: pytest hypothesis docutils
             task: PYTHONPATH=./src make -f Makefile test-travis
     runs-on: ubuntu-latest
     steps:
@@ -54,7 +54,7 @@ jobs:
             task: yamllint
           - dependencies: python python3-build twine
             task: package
-          - dependencies: pylint python3-six
+          - dependencies: pylint
             task: lint
     runs-on: ubuntu-latest
     container: fedora:35  # CURRENT DEVELOPMENT ENVIRONMENT

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -18,7 +18,7 @@ jobs:
             task: yamllint
           - dependencies: python python3-build twine
             task: package
-          - dependencies: pylint python3-six
+          - dependencies: pylint
             task: lint
     runs-on: ubuntu-latest
     container: fedora:35  # NEXT DEVELOPMENT ENVIRONMENT

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ setuptools.setup(
         "Topic :: System :: Hardware",
         "Topic :: System :: Operating System Kernels :: Linux",
     ],
-    install_requires=["six"],
     package_dir={"": "src"},
     packages=setuptools.find_packages("src"),
 )

--- a/src/pyudev/_errors.py
+++ b/src/pyudev/_errors.py
@@ -29,18 +29,15 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 # isort: STDLIB
 import abc
 
-# isort: THIRDPARTY
-from six import add_metaclass
 
-
-@add_metaclass(abc.ABCMeta)
 class DeviceError(Exception):
     """
     Any error raised when messing around w/ or trying to discover devices.
     """
 
+    __metaclass__ = abc.ABCMeta
 
-@add_metaclass(abc.ABCMeta)
+
 class DeviceNotFoundError(DeviceError):
     """
     An exception indicating that no :class:`Device` was found.
@@ -48,6 +45,8 @@ class DeviceNotFoundError(DeviceError):
     .. versionchanged:: 0.5
        Rename from ``NoSuchDeviceError`` to its current name.
     """
+
+    __metaclass__ = abc.ABCMeta
 
 
 class DeviceNotFoundAtPathError(DeviceNotFoundError):

--- a/src/pyudev/_qt_base.py
+++ b/src/pyudev/_qt_base.py
@@ -26,9 +26,6 @@
 # isort: FUTURE
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-# isort: THIRDPARTY
-import six
-
 # isort: LOCAL
 from pyudev.device import Device
 
@@ -201,7 +198,7 @@ class QUDevMonitorObserverGenerator(object):
             {
                 str("__init__"): make_init(qobject, socket_notifier),
                 #: emitted upon arbitrary device events
-                str("deviceEvent"): signal(six.text_type, Device),
+                str("deviceEvent"): signal(str, Device),
                 #: emitted if a device was added
                 str("deviceAdded"): signal(Device),
                 #: emitted if a device was removed

--- a/src/pyudev/_util.py
+++ b/src/pyudev/_util.py
@@ -32,9 +32,6 @@ import os
 import stat
 import sys
 
-# isort: THIRDPARTY
-import six
-
 try:
     # isort: STDLIB
     from subprocess import check_output
@@ -64,7 +61,7 @@ def ensure_unicode_string(value):
     decoded with the filesystem encoding (as in
     :func:`sys.getfilesystemencoding()`).
     """
-    if not isinstance(value, six.text_type):
+    if not isinstance(value, str):
         value = value.decode(sys.getfilesystemencoding())
     return value
 
@@ -86,7 +83,7 @@ def property_value_to_bytes(value):
         value = int(value)
     if isinstance(value, bytes):
         return value
-    return ensure_byte_string(six.text_type(value))
+    return ensure_byte_string(str(value))
 
 
 def string_to_bool(value):

--- a/src/pyudev/device/_device.py
+++ b/src/pyudev/device/_device.py
@@ -27,14 +27,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 # isort: STDLIB
+import collections
 import os
 import re
 import sys
 from datetime import timedelta
-
-# isort: THIRDPARTY
-import six
-from six.moves import collections_abc
 
 # isort: LOCAL
 from pyudev._errors import (
@@ -53,15 +50,6 @@ from pyudev._util import (
     string_to_bool,
     udev_list_iterate,
 )
-
-six.add_move(
-    six.MovedModule(
-        "collections_abc",
-        "collections",
-        "collections.abc" if sys.version_info >= (3, 3) else "collections",
-    )
-)
-
 
 # pylint: disable=too-many-lines
 
@@ -340,7 +328,7 @@ class Devices(object):
         ]
 
 
-class Device(collections_abc.Mapping):
+class Device(collections.abc.Mapping):
     # pylint: disable=too-many-public-methods
     """
     A single device with attached attributes and properties.
@@ -482,7 +470,7 @@ class Device(collections_abc.Mapping):
         return Devices.from_environment(context)
 
     def __init__(self, context, _device):
-        collections_abc.Mapping.__init__(self)
+        collections.abc.Mapping.__init__(self)
         self.context = context
         self._as_parameter_ = _device
         self._libudev = context._libudev
@@ -1067,7 +1055,7 @@ class Device(collections_abc.Mapping):
         raise TypeError("Device not orderable")
 
 
-class Properties(collections_abc.Mapping):
+class Properties(collections.abc.Mapping):
     """
     udev properties :class:`Device` objects.
 
@@ -1075,7 +1063,7 @@ class Properties(collections_abc.Mapping):
     """
 
     def __init__(self, device):
-        collections_abc.Mapping.__init__(self)
+        collections.abc.Mapping.__init__(self)
         self.device = device
         self._libudev = device._libudev
 
@@ -1260,7 +1248,7 @@ class Attributes(object):
         return string_to_bool(self.asstring(attribute))
 
 
-class Tags(collections_abc.Iterable, collections_abc.Container):
+class Tags(collections.abc.Iterable, collections.abc.Container):
     """
     A iterable over :class:`Device` tags.
 
@@ -1271,7 +1259,7 @@ class Tags(collections_abc.Iterable, collections_abc.Container):
 
     def __init__(self, device):
         # pylint: disable=super-init-not-called
-        collections_abc.Iterable.__init__(self)
+        collections.abc.Iterable.__init__(self)
         self.device = device
         self._libudev = device._libudev
 

--- a/src/pyudev/discover.py
+++ b/src/pyudev/discover.py
@@ -32,9 +32,6 @@ import functools
 import os
 import re
 
-# isort: THIRDPARTY
-import six
-
 # isort: LOCAL
 from pyudev._errors import DeviceNotFoundError
 from pyudev.device import Devices
@@ -60,11 +57,12 @@ def wrap_exception(func):
     return the_func
 
 
-@six.add_metaclass(abc.ABCMeta)
 class Hypothesis(object):
     """
     Represents a hypothesis about the meaning of the device identifier.
     """
+
+    __metaclass__ = abc.ABCMeta
 
     @classmethod
     @abc.abstractmethod

--- a/tests/utils/misc.py
+++ b/tests/utils/misc.py
@@ -31,7 +31,6 @@ from functools import wraps
 
 # isort: THIRDPARTY
 import pytest
-import six
 from hypothesis.core import FailedHealthCheck
 
 
@@ -40,7 +39,7 @@ def is_unicode_string(value):
     Return ``True``, if ``value`` is of a real unicode string type
     (``unicode`` in python 2, ``str`` in python 3), ``False`` otherwise.
     """
-    return isinstance(value, unicode if six.PY2 else str)
+    return isinstance(value, str)
 
 
 def failed_health_check_wrapper(func):
@@ -56,10 +55,13 @@ def failed_health_check_wrapper(func):
         try:
             func(*args)
         except FailedHealthCheck:
-            func_code = six.get_function_code(func)
             pytest.skip(
                 "failed health check for %s() (%s: %s)"
-                % (func_code.co_name, func_code.co_filename, func_code.co_firstlineno)
+                % (
+                    func.__code__.co_name,
+                    func.__code__.co_filename,
+                    func.__code__.co_firstlineno,
+                )
             )
 
     return the_func

--- a/tests/utils/udev.py
+++ b/tests/utils/udev.py
@@ -29,23 +29,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 # isort: STDLIB
+import collections
 import errno
 import os
 import re
 import subprocess
 import sys
-
-# isort: THIRDPARTY
-import six
-from six.moves import collections_abc
-
-six.add_move(
-    six.MovedModule(
-        "collections_abc",
-        "collections",
-        "collections.abc" if sys.version_info >= (3, 3) else "collections",
-    )
-)
 
 
 class UDevAdm(object):
@@ -287,7 +276,7 @@ class DeviceData(object):
         return 0 if device_node is None else os.stat(device_node).st_rdev
 
 
-class DeviceDatabase(collections_abc.Iterable, collections_abc.Sized):
+class DeviceDatabase(collections.abc.Iterable, collections.abc.Sized):
     """
     The udev device database.
 


### PR DESCRIPTION
Obviously this makes pyudev incompatible with Python 2 but Python 2 will
be dead soon anyways.

https://pythonclock.org/