### PR TITLE
tests: fix tests for pytest 4.0

### DIFF
--- a/tests/plugins/mock_libudev.py
+++ b/tests/plugins/mock_libudev.py
@@ -32,6 +32,7 @@ from operator import attrgetter
 from contextlib import contextmanager
 from collections import namedtuple
 
+import pytest
 import mock
 
 Node = namedtuple('Node', 'name value next')
@@ -93,5 +94,6 @@ def libudev_list(libudev, function, items):
 EXPOSED_FUNCTIONS = [libudev_list]
 
 
-def pytest_namespace():
-    return dict((f.__name__, f) for f in EXPOSED_FUNCTIONS)
+def pytest_configure():
+    for f in EXPOSED_FUNCTIONS:
+        setattr(pytest, f.__name__, f)

--- a/tests/plugins/privileged.py
+++ b/tests/plugins/privileged.py
@@ -71,5 +71,6 @@ def unload_dummy():
 EXPOSED_FUNCTIONS = [load_dummy, unload_dummy]
 
 
-def pytest_namespace():
-    return dict((f.__name__, f) for f in EXPOSED_FUNCTIONS)
+def pytest_configure():
+    for f in EXPOSED_FUNCTIONS:
+        setattr(pytest, f.__name__, f)

--- a/tests/plugins/travis.py
+++ b/tests/plugins/travis.py
@@ -38,8 +38,9 @@ def is_on_travis_ci():
 EXPOSED_FUNCTIONS = [is_on_travis_ci]
 
 
-def pytest_namespace():
-    return dict((f.__name__, f) for f in EXPOSED_FUNCTIONS)
+def pytest_configure():
+    for f in EXPOSED_FUNCTIONS:
+        setattr(pytest, f.__name__, f)
 
 
 def pytest_runtest_setup(item):


### PR DESCRIPTION
`pytest_namespace` was removed in pytest 4.0, we should use `pytest_configure` instead.

https://docs.pytest.org/en/latest/deprecations.html#pytest-namespace