### PR TITLE
tests: use pytest.ini instead of setup.cfg to configure pytest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ include tox.ini
 global-include requirements.txt
 include CHANGES.rst COPYING README.rst
 include setup.py setup.cfg
+include pytest.ini

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[tool:pytest]
+# do not search for tests in build directory
+norecursedirs = .* _* build

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,3 @@ release = egg_info -RDb ''
 
 [upload_docs]
 upload_dir = build/sphinx/html
-
-[tool:pytest]
-# do not search for tests in build directory
-norecursedirs = .* _* build


### PR DESCRIPTION
Configuring pytest in `setup.cfg` works fine when invoking pytest directly but doesn't work when using [pytest-runner](https://github.com/pytest-dev/pytest-runner). This patch should maintain all compatibility and additionally support pytest-runner.