### PR TITLE
clarify Deprecation warning triggered by __len__

### DIFF
--- a/src/pyudev/device/_device.py
+++ b/src/pyudev/device/_device.py
@@ -911,7 +911,7 @@ class Device(Mapping):
         """
         import warnings
         warnings.warn(
-            'Will be removed in 1.0. Access properties with Device.properties.',
+            'Will be removed in 1.0. Access the amount of properties with len(Device.properties). If you are testing if the Device exists, compare explicitly against None.',
             DeprecationWarning,
             stacklevel=2)
         return self.properties.__len__()


### PR DESCRIPTION
Took me a while to understand that the generic Deprecation warning `DeprecationWarning: Will be removed in 1.0. Access properties with Device.properties.` was being triggered by the following comparison (triggered by python checking the length of the object, itself calling __len__ on the Device class):

```
if device:
    pass
```

While it is bad practice not to compare device against None, the warning can be improved to help the user a little bit more.