### PR TITLE
tests: rename pytest field in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,6 @@ release = egg_info -RDb ''
 [upload_docs]
 upload_dir = build/sphinx/html
 
-[pytest]
+[tool:pytest]
 # do not search for tests in build directory
 norecursedirs = .* _* build


### PR DESCRIPTION
`[pytest]` no longer works, it was moved to `[tool:pytest]`

Signed-off-by: Filipe Laíns <lains@archlinux.org>