### PR TITLE
Drop support for Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,13 @@ matrix:
           env: TASK=fmt-travis
         - python: 3.6
           env: TASK=pylint
-        - python: 2.7
-          env: TASK=test-travis
         - python: 3.4
           env: TASK=test-travis
         - python: 3.5
           env: TASK=test-travis
         - python: 3.6
           env: TASK=test-travis
-        - python: pypy
+        - python: pypy3
           env: TASK=test-travis
 
 

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ archive:
 
 .PHONY: test-travis
 test-travis:
-	py.test --junitxml=tests.xml --enable-privileged -rfEsxX
+	pytest --junitxml=tests.xml --enable-privileged -rfEsxX
 
 .PHONY: fmt
 fmt:

--- a/README.rst
+++ b/README.rst
@@ -13,9 +13,9 @@ libudev_ functionality. You can enumerate devices, query device properties and
 attributes or monitor devices, including asynchronous monitoring with threads,
 or within the event loops of Qt, Glib or wxPython.
 
-The binding supports CPython_ 2 (2.6 or newer) and 3 (3.1 or newer), and PyPy_
-1.5 or newer.  It is tested against udev 151 or newer, earlier versions of udev
-as found on dated Linux systems may work, but are not officially supported.
+The binding supports CPython_ 3.1 or newer, and PyPy_ 1.5 or newer.  It is
+tested against udev 151 or newer, earlier versions of udev as found on dated
+Linux systems may work, but are not officially supported.
 
 
 Usage

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012, 2013 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -16,8 +15,6 @@
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)
 
 import sys
 import os
@@ -34,7 +31,7 @@ sys.path.append(os.path.normpath(
     os.path.join(doc_directory, os.pardir, 'tests')))
 
 
-class Mock(object):
+class Mock:
     """
     Mock modules.
 
@@ -95,8 +92,8 @@ master_doc = 'index'
 exclude_patterns = ['_build/*']
 source_suffix = '.rst'
 
-project = u'pyudev'
-copyright = u'2010, 2011 Sebastian Wiesner'
+project = 'pyudev'
+copyright = '2010, 2011 Sebastian Wiesner'
 version = '.'.join(pyudev.__version__.split('.')[:2])
 release = pyudev.__version__
 
@@ -122,7 +119,7 @@ class UDevVersion(Directive):
     def run(self):
         udevversion = self.arguments[0]
         para = nodes.paragraph(udevversion, '', classes=['udevversion'])
-        text = 'Required udev version: {0}'.format(*self.arguments)
+        text = 'Required udev version: {}'.format(*self.arguments)
         node = nodes.inline(udevversion, text, classes=['versionmodified'])
         para.append(node)
         return [para]

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -4,9 +4,9 @@ Installation
 Python versions and implementations
 -----------------------------------
 
-pyudev supports CPython from 2.6 up to the latest Python 3 release, and PyPy
+pyudev supports CPython from 3.1 up to the latest Python 3 release, and PyPy
 1.5. Jython may work, too, but is not tested. Generally any Python
-implementation compatible with CPython 2.6 should work.
+implementation compatible with CPython 3.1 should work.
 
 
 Dependencies

--- a/doc/tests/plugins.rst
+++ b/doc/tests/plugins.rst
@@ -21,9 +21,9 @@ The following plugins are provided and enabled:
 Command line options
 ~~~~~~~~~~~~~~~~~~~~
 
-The plugin adds the following command line options to :program:`py.test`:
+The plugin adds the following command line options to :program:`pytest`:
 
-.. program:: py.test
+.. program:: pytest
 
 .. option:: --enable-privileged
 

--- a/doc/tests/running.rst
+++ b/doc/tests/running.rst
@@ -9,13 +9,13 @@ If you are on a Linux system run all tests with tox_.  This tool automatically
 creates virtualenvs (see virtualenv_), installs all packages required by the
 test suite, and runs the tests.
 
-Run all pyudev tests against Python 2.7, Python 3.2 and PyPy::
+Run all pyudev tests against Python 3.2 and PyPy::
 
-   tox -e py27,py32,pypy
+   tox -e py32,pypy
 
 Pass any arguments you want to :program:`py.test` after two dashes ``--``::
 
-   tox -e py27,py32,pypy -- --enable-privileged
+   tox -e py32,pypy -- --enable-privileged
 
 
 Notes

--- a/doc/tests/running.rst
+++ b/doc/tests/running.rst
@@ -13,7 +13,7 @@ Run all pyudev tests against Python 3.2 and PyPy::
 
    tox -e py32,pypy
 
-Pass any arguments you want to :program:`py.test` after two dashes ``--``::
+Pass any arguments you want to :program:`pytest` after two dashes ``--``::
 
    tox -e py32,pypy -- --enable-privileged
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # unit test requirements
 docutils>=0.9
 pytest>=2.8
-mock>=1.0b1
 hypothesis==3.66.1
 
 # documentation requirements

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,6 @@
 import os
 import sys
 import setuptools
-if sys.version_info[0] < 3:
-    from codecs import open
 
 
 def local_file(name):
@@ -47,8 +45,7 @@ setuptools.setup(
         'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries',

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setuptools.setup(
         'Topic :: System :: Hardware',
         'Topic :: System :: Operating System Kernels :: Linux',
     ],
-    install_requires=['six'],
     package_dir={"": "src"},
     packages=setuptools.find_packages("src"),
 )

--- a/src/pyudev/__init__.py
+++ b/src/pyudev/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -32,10 +31,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from pyudev._errors import DeviceNotFoundAtPathError
 from pyudev._errors import DeviceNotFoundByFileError

--- a/src/pyudev/__init__.py
+++ b/src/pyudev/__init__.py
@@ -31,7 +31,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-
 from pyudev._errors import DeviceNotFoundAtPathError
 from pyudev._errors import DeviceNotFoundByFileError
 from pyudev._errors import DeviceNotFoundByNameError

--- a/src/pyudev/_compat.py
+++ b/src/pyudev/_compat.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2011 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -23,16 +22,13 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)
 
 from subprocess import Popen, CalledProcessError, PIPE
 
 
 def check_output(command):
     """
-    Compatibility with :func:`subprocess.check_output` from Python 2.7 and
-    upwards.
+    Compatibility with :func:`subprocess.check_output`.
     """
     proc = Popen(command, stdout=PIPE)
     output = proc.communicate()[0]

--- a/src/pyudev/_compat.py
+++ b/src/pyudev/_compat.py
@@ -22,7 +22,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-
 from subprocess import Popen, CalledProcessError, PIPE
 
 

--- a/src/pyudev/_ctypeslib/__init__.py
+++ b/src/pyudev/_ctypeslib/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2015 mulhern <amulhern@redhat.com>
 
 # This library is free software; you can redistribute it and/or modify it

--- a/src/pyudev/_ctypeslib/_errorcheckers.py
+++ b/src/pyudev/_ctypeslib/_errorcheckers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2013 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -21,10 +20,6 @@
     Error checkers for ctypes wrappers.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import os
 import errno

--- a/src/pyudev/_ctypeslib/_errorcheckers.py
+++ b/src/pyudev/_ctypeslib/_errorcheckers.py
@@ -20,7 +20,6 @@
     Error checkers for ctypes wrappers.
 """
 
-
 import os
 import errno
 from ctypes import get_errno

--- a/src/pyudev/_ctypeslib/libc.py
+++ b/src/pyudev/_ctypeslib/libc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2013 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -23,10 +22,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from ctypes import c_int
 

--- a/src/pyudev/_ctypeslib/libc.py
+++ b/src/pyudev/_ctypeslib/libc.py
@@ -22,7 +22,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-
 from ctypes import c_int
 
 from ._errorcheckers import check_errno_on_nonzero_return

--- a/src/pyudev/_ctypeslib/libudev.py
+++ b/src/pyudev/_ctypeslib/libudev.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012, 2013 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -24,10 +23,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from ctypes import c_char
 from ctypes import c_char_p

--- a/src/pyudev/_ctypeslib/libudev.py
+++ b/src/pyudev/_ctypeslib/libudev.py
@@ -23,7 +23,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-
 from ctypes import c_char
 from ctypes import c_char_p
 from ctypes import c_int

--- a/src/pyudev/_ctypeslib/utils.py
+++ b/src/pyudev/_ctypeslib/utils.py
@@ -22,7 +22,6 @@
     .. moduleauthor::  Anne Mulhern  <amulhern@redhat.com>
 """
 
-
 from ctypes import CDLL
 from ctypes.util import find_library
 

--- a/src/pyudev/_ctypeslib/utils.py
+++ b/src/pyudev/_ctypeslib/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2013 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -23,10 +22,6 @@
     .. moduleauthor::  Anne Mulhern  <amulhern@redhat.com>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from ctypes import CDLL
 from ctypes.util import find_library

--- a/src/pyudev/_errors.py
+++ b/src/pyudev/_errors.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2015 mulhern <amulhern@redhat.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -23,25 +22,19 @@
     .. moduleauthor:: Sebastian Wiesner <lunaryorn@gmail.com>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import abc
 
 from six import add_metaclass
 
 
-@add_metaclass(abc.ABCMeta)
-class DeviceError(Exception):
+class DeviceError(Exception, metaclass=abc.ABCMeta):
     """
     Any error raised when messing around w/ or trying to discover devices.
     """
 
 
-@add_metaclass(abc.ABCMeta)
-class DeviceNotFoundError(DeviceError):
+class DeviceNotFoundError(DeviceError, metaclass=abc.ABCMeta):
     """
     An exception indicating that no :class:`Device` was found.
 
@@ -67,7 +60,7 @@ class DeviceNotFoundAtPathError(DeviceNotFoundError):
         return self.args[0]
 
     def __str__(self):
-        return 'No device at {0!r}'.format(self.sys_path)
+        return 'No device at {!r}'.format(self.sys_path)
 
 
 class DeviceNotFoundByFileError(DeviceNotFoundError):

--- a/src/pyudev/_errors.py
+++ b/src/pyudev/_errors.py
@@ -22,7 +22,6 @@
     .. moduleauthor:: Sebastian Wiesner <lunaryorn@gmail.com>
 """
 
-
 import abc
 
 from six import add_metaclass

--- a/src/pyudev/_errors.py
+++ b/src/pyudev/_errors.py
@@ -24,8 +24,6 @@
 
 import abc
 
-from six import add_metaclass
-
 
 class DeviceError(Exception, metaclass=abc.ABCMeta):
     """

--- a/src/pyudev/_os/__init__.py
+++ b/src/pyudev/_os/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2015 mulhern <amulhern@redhat.com>
 
 # This library is free software; you can redistribute it and/or modify it

--- a/src/pyudev/_os/pipe.py
+++ b/src/pyudev/_os/pipe.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2013 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -29,10 +28,6 @@
     .. moduleauthor:: Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import os
 import fcntl
@@ -121,7 +116,7 @@ def set_fd_status_flag(fd, flag):
     fcntl.fcntl(fd, fcntl.F_SETFL, flags | flag)
 
 
-class Pipe(object):
+class Pipe:
     """A unix pipe.
 
     A pipe object provides two file objects: :attr:`source` is a readable file

--- a/src/pyudev/_os/pipe.py
+++ b/src/pyudev/_os/pipe.py
@@ -28,7 +28,6 @@
     .. moduleauthor:: Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-
 import os
 import fcntl
 from functools import partial

--- a/src/pyudev/_os/poll.py
+++ b/src/pyudev/_os/poll.py
@@ -22,7 +22,6 @@
     .. moduleauthor:: Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-
 import select
 
 from pyudev._util import eintr_retry_call

--- a/src/pyudev/_os/poll.py
+++ b/src/pyudev/_os/poll.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2013 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -23,17 +22,13 @@
     .. moduleauthor:: Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import select
 
 from pyudev._util import eintr_retry_call
 
 
-class Poll(object):
+class Poll:
     """A poll object.
 
     This object essentially provides a more convenient interface around
@@ -61,7 +56,7 @@ class Poll(object):
         for fd, event in events:
             mask = cls._EVENT_TO_MASK.get(event)
             if not mask:
-                raise ValueError('Unknown event type: {0!r}'.format(event))
+                raise ValueError('Unknown event type: {!r}'.format(event))
             notifier.register(fd, mask)
         return cls(notifier)
 
@@ -105,9 +100,9 @@ class Poll(object):
         """
         for fd, event_mask in events:
             if self._has_event(event_mask, select.POLLNVAL):
-                raise IOError('File descriptor not open: {0!r}'.format(fd))
+                raise OSError('File descriptor not open: {!r}'.format(fd))
             elif self._has_event(event_mask, select.POLLERR):
-                raise IOError('Error while polling fd: {0!r}'.format(fd))
+                raise OSError('Error while polling fd: {!r}'.format(fd))
 
             if self._has_event(event_mask, select.POLLIN):
                 yield fd, 'r'

--- a/src/pyudev/_qt_base.py
+++ b/src/pyudev/_qt_base.py
@@ -22,7 +22,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-
 import six
 
 from pyudev.device import Device
@@ -187,21 +186,15 @@ class QUDevMonitorObserverGenerator:
             "QUDevMonitorObserver",
             (qobject, QUDevMonitorObserverMixin),
             {
-                "__init__":
-                make_init(qobject, socket_notifier),
+                "__init__": make_init(qobject, socket_notifier),
                 #: emitted upon arbitrary device events
-                "deviceEvent":
-                signal(str, Device),
+                "deviceEvent": signal(str, Device),
                 #: emitted if a device was added
-                "deviceAdded":
-                signal(Device),
+                "deviceAdded": signal(Device),
                 #: emitted if a device was removed
-                "deviceRemoved":
-                signal(Device),
+                "deviceRemoved": signal(Device),
                 #: emitted if a device was changed
-                "deviceChanged":
-                signal(Device),
+                "deviceChanged": signal(Device),
                 #: emitted if a device was moved
-                "deviceMoved":
-                signal(Device)
+                "deviceMoved": signal(Device)
             })

--- a/src/pyudev/_qt_base.py
+++ b/src/pyudev/_qt_base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012, 2013 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -23,17 +22,13 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import six
 
 from pyudev.device import Device
 
 
-class MonitorObserverMixin(object):
+class MonitorObserverMixin:
     """
     Base mixin for pyqt monitor observers.
     """
@@ -125,7 +120,7 @@ def make_init(qobject, socket_notifier):
     return __init__
 
 
-class MonitorObserverGenerator(object):
+class MonitorObserverGenerator:
     """
     Class to generate a MonitorObserver class.
     """
@@ -154,13 +149,13 @@ class MonitorObserverGenerator(object):
 
         """
         return type(
-            str("MonitorObserver"), (qobject, MonitorObserverMixin), {
-                str("__init__"): make_init(qobject, socket_notifier),
-                str("deviceEvent"): signal(Device)
+            "MonitorObserver", (qobject, MonitorObserverMixin), {
+                "__init__": make_init(qobject, socket_notifier),
+                "deviceEvent": signal(Device)
             })
 
 
-class QUDevMonitorObserverGenerator(object):
+class QUDevMonitorObserverGenerator:
     """
     Class to generate a MonitorObserver class.
     """
@@ -189,24 +184,24 @@ class QUDevMonitorObserverGenerator(object):
 
         """
         return type(
-            str("QUDevMonitorObserver"),
+            "QUDevMonitorObserver",
             (qobject, QUDevMonitorObserverMixin),
             {
-                str("__init__"):
+                "__init__":
                 make_init(qobject, socket_notifier),
                 #: emitted upon arbitrary device events
-                str("deviceEvent"):
-                signal(six.text_type, Device),
+                "deviceEvent":
+                signal(str, Device),
                 #: emitted if a device was added
-                str("deviceAdded"):
+                "deviceAdded":
                 signal(Device),
                 #: emitted if a device was removed
-                str("deviceRemoved"):
+                "deviceRemoved":
                 signal(Device),
                 #: emitted if a device was changed
-                str("deviceChanged"):
+                "deviceChanged":
                 signal(Device),
                 #: emitted if a device was moved
-                str("deviceMoved"):
+                "deviceMoved":
                 signal(Device)
             })

--- a/src/pyudev/_qt_base.py
+++ b/src/pyudev/_qt_base.py
@@ -22,8 +22,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-import six
-
 from pyudev.device import Device
 
 

--- a/src/pyudev/_util.py
+++ b/src/pyudev/_util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -23,8 +22,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)
 
 try:
     from subprocess import check_output
@@ -60,7 +57,7 @@ def ensure_unicode_string(value):
     decoded with the filesystem encoding (as in
     :func:`sys.getfilesystemencoding()`).
     """
-    if not isinstance(value, six.text_type):
+    if not isinstance(value, str):
         value = value.decode(sys.getfilesystemencoding())
     return value
 
@@ -82,7 +79,7 @@ def property_value_to_bytes(value):
         value = int(value)
     if isinstance(value, bytes):
         return value
-    return ensure_byte_string(six.text_type(value))
+    return ensure_byte_string(str(value))
 
 
 def string_to_bool(value):
@@ -94,7 +91,7 @@ def string_to_bool(value):
     :exc:`~exceptions.ValueError`.
     """
     if value not in ('1', '0'):
-        raise ValueError('Not a boolean value: {0!r}'.format(value))
+        raise ValueError('Not a boolean value: {!r}'.format(value))
     return value == '1'
 
 
@@ -133,7 +130,7 @@ def get_device_type(filename):
     elif stat.S_ISBLK(mode):
         return 'block'
     else:
-        raise ValueError('not a device file: {0!r}'.format(filename))
+        raise ValueError('not a device file: {!r}'.format(filename))
 
 
 def eintr_retry_call(func, *args, **kwargs):
@@ -157,7 +154,7 @@ def eintr_retry_call(func, *args, **kwargs):
     while True:
         try:
             return func(*args, **kwargs)
-        except (OSError, IOError, select.error) as err:
+        except OSError as err:
             # If this is not an IOError or OSError, it's the old select.error
             # type, which means that the errno is only accessible via subscript
             if isinstance(err, (OSError, IOError)):
@@ -190,8 +187,8 @@ def udev_version():
     could not be converted to an integer.  Raise
     :exc:`~exceptions.EnvironmentError`, if ``udevadm`` was not found, or could
     not be executed.  Raise :exc:`subprocess.CalledProcessError`, if
-    ``udevadm`` returned a non-zero exit code.  On Python 2.7 or newer, the
-    ``output`` attribute of this exception is correctly set.
+    ``udevadm`` returned a non-zero exit code. The ``output`` attribute of this
+    exception is correctly set.
 
     .. versionadded:: 0.8
     """

--- a/src/pyudev/_util.py
+++ b/src/pyudev/_util.py
@@ -32,8 +32,6 @@ import sys
 import stat
 import errno
 
-import six
-
 
 def ensure_byte_string(value):
     """

--- a/src/pyudev/_util.py
+++ b/src/pyudev/_util.py
@@ -22,7 +22,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-
 try:
     from subprocess import check_output
 except ImportError:

--- a/src/pyudev/_util.py
+++ b/src/pyudev/_util.py
@@ -145,9 +145,6 @@ def eintr_retry_call(func, *args, **kwargs):
     This function is based on _eintr_retry_call in python's subprocess.py.
     """
 
-    # select.error inherits from Exception instead of OSError in Python 2
-    import select
-
     while True:
         try:
             return func(*args, **kwargs)

--- a/src/pyudev/core.py
+++ b/src/pyudev/core.py
@@ -22,7 +22,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-
 from pyudev.device import Devices
 from pyudev._errors import DeviceNotFoundAtPathError
 from pyudev._ctypeslib.libudev import ERROR_CHECKERS

--- a/src/pyudev/core.py
+++ b/src/pyudev/core.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -23,8 +22,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)
 
 from pyudev.device import Devices
 from pyudev._errors import DeviceNotFoundAtPathError
@@ -38,7 +35,7 @@ from pyudev._util import property_value_to_bytes
 from pyudev._util import udev_list_iterate
 
 
-class Context(object):
+class Context:
     """
     A device database connection.
 
@@ -142,7 +139,7 @@ class Context(object):
         return Enumerator(self).match(**kwargs)
 
 
-class Enumerator(object):
+class Enumerator:
     """
     A filtered iterable of devices.
 

--- a/src/pyudev/device/__init__.py
+++ b/src/pyudev/device/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2015 mulhern <amulhern@redhat.com>
 
 # This library is free software; you can redistribute it and/or modify it

--- a/src/pyudev/device/_device.py
+++ b/src/pyudev/device/_device.py
@@ -22,7 +22,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-
 import os
 import re
 from collections import Container

--- a/src/pyudev/device/_device.py
+++ b/src/pyudev/device/_device.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2011, 2012 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -23,10 +22,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import os
 import re
@@ -51,7 +46,7 @@ from pyudev._util import udev_list_iterate
 # pylint: disable=too-many-lines
 
 
-class Devices(object):
+class Devices:
     """
     Class for constructing :class:`Device` objects from various kinds of data.
     """
@@ -218,7 +213,7 @@ class Devices(object):
         try:
             device_type = get_device_type(filename)
             device_number = os.stat(filename).st_rdev
-        except (EnvironmentError, ValueError) as err:
+        except (OSError, ValueError) as err:
             raise DeviceNotFoundByFileError(err)
 
         return cls.from_device_number(context, device_type, device_number)
@@ -1092,7 +1087,7 @@ class Properties(Mapping):
         return string_to_bool(self[prop])
 
 
-class Attributes(object):
+class Attributes:
     """
     udev attributes for :class:`Device` objects.
 

--- a/src/pyudev/discover.py
+++ b/src/pyudev/discover.py
@@ -26,7 +26,6 @@ import abc
 import functools
 import os
 import re
-import six
 
 from pyudev._errors import DeviceNotFoundError
 

--- a/src/pyudev/discover.py
+++ b/src/pyudev/discover.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2015 mulhern <amulhern@redhat.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -23,10 +22,6 @@
     .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import abc
 import functools
@@ -59,8 +54,7 @@ def wrap_exception(func):
     return the_func
 
 
-@six.add_metaclass(abc.ABCMeta)
-class Hypothesis(object):
+class Hypothesis(metaclass=abc.ABCMeta):
     """
     Represents a hypothesis about the meaning of the device identifier.
     """
@@ -297,7 +291,7 @@ class DeviceFileHypothesis(Hypothesis):
         devices = context.list_devices()
         devices_with_links = (d for d in devices if list(d.device_links))
         links = (l for d in devices_with_links for l in d.device_links)
-        return sorted(set(os.path.dirname(l) for l in links))
+        return sorted({os.path.dirname(l) for l in links})
 
     @classmethod
     def setup(cls, context):
@@ -338,7 +332,7 @@ class DeviceFileHypothesis(Hypothesis):
         return frozenset(d for d in devices if d is not None)
 
 
-class Discovery(object):
+class Discovery:
     # pylint: disable=too-few-public-methods
     """
     Provides discovery methods for devices.

--- a/src/pyudev/discover.py
+++ b/src/pyudev/discover.py
@@ -22,7 +22,6 @@
     .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-
 import abc
 import functools
 import os

--- a/src/pyudev/glib.py
+++ b/src/pyudev/glib.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012, 2013 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -32,8 +31,6 @@
 
 """
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)
 
 # thanks to absolute imports, this really imports the glib binding and not this
 # module again
@@ -41,7 +38,7 @@ import glib  # pylint: disable=import-error
 import gobject  # pylint: disable=import-error
 
 
-class _ObserverMixin(object):
+class _ObserverMixin:
     """Mixin to provide observer behavior to the old and the new API."""
 
     # pylint: disable=too-few-public-methods
@@ -117,7 +114,7 @@ class MonitorObserver(gobject.GObject, _ObserverMixin):
         # python versions.  We could also remove the "unicode_literals" import,
         # but I don't want to make exceptions to the standard set of future
         # imports used throughout pyudev for the sake of consistency.
-        str('device-event'): (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
+        'device-event': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
                               (gobject.TYPE_PYOBJECT, )),
     }
 
@@ -146,15 +143,15 @@ class GUDevMonitorObserver(gobject.GObject, _ObserverMixin):
     }
 
     __gsignals__ = {
-        str('device-event'): (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
+        'device-event': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
                               (gobject.TYPE_STRING, gobject.TYPE_PYOBJECT)),
-        str('device-added'): (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
+        'device-added': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
                               (gobject.TYPE_PYOBJECT, )),
-        str('device-removed'): (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
+        'device-removed': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
                                 (gobject.TYPE_PYOBJECT, )),
-        str('device-changed'): (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
+        'device-changed': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
                                 (gobject.TYPE_PYOBJECT, )),
-        str('device-moved'): (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
+        'device-moved': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
                               (gobject.TYPE_PYOBJECT, )),
     }
 

--- a/src/pyudev/glib.py
+++ b/src/pyudev/glib.py
@@ -31,7 +31,6 @@
 
 """
 
-
 # thanks to absolute imports, this really imports the glib binding and not this
 # module again
 import glib  # pylint: disable=import-error
@@ -115,7 +114,7 @@ class MonitorObserver(gobject.GObject, _ObserverMixin):
         # but I don't want to make exceptions to the standard set of future
         # imports used throughout pyudev for the sake of consistency.
         'device-event': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
-                              (gobject.TYPE_PYOBJECT, )),
+                         (gobject.TYPE_PYOBJECT, )),
     }
 
     def __init__(self, monitor):
@@ -144,15 +143,15 @@ class GUDevMonitorObserver(gobject.GObject, _ObserverMixin):
 
     __gsignals__ = {
         'device-event': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
-                              (gobject.TYPE_STRING, gobject.TYPE_PYOBJECT)),
+                         (gobject.TYPE_STRING, gobject.TYPE_PYOBJECT)),
         'device-added': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
-                              (gobject.TYPE_PYOBJECT, )),
+                         (gobject.TYPE_PYOBJECT, )),
         'device-removed': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
-                                (gobject.TYPE_PYOBJECT, )),
+                           (gobject.TYPE_PYOBJECT, )),
         'device-changed': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
-                                (gobject.TYPE_PYOBJECT, )),
+                           (gobject.TYPE_PYOBJECT, )),
         'device-moved': (gobject.SIGNAL_RUN_LAST, gobject.TYPE_NONE,
-                              (gobject.TYPE_PYOBJECT, )),
+                         (gobject.TYPE_PYOBJECT, )),
     }
 
     def __init__(self, monitor):

--- a/src/pyudev/monitor.py
+++ b/src/pyudev/monitor.py
@@ -22,7 +22,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-
 import os
 import errno
 from threading import Thread

--- a/src/pyudev/monitor.py
+++ b/src/pyudev/monitor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012, 2013 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -23,8 +22,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)
 
 import os
 import errno
@@ -40,7 +37,7 @@ from pyudev._os import pipe
 from pyudev._os import poll
 
 
-class Monitor(object):
+class Monitor:
     """
     A synchronous device event monitor.
 
@@ -113,12 +110,12 @@ class Monitor(object):
         failed.
         """
         if source not in ('kernel', 'udev'):
-            raise ValueError('Invalid source: {0!r}. Must be one of "udev" '
+            raise ValueError('Invalid source: {!r}. Must be one of "udev" '
                              'or "kernel"'.format(source))
         monitor = context._libudev.udev_monitor_new_from_netlink(
             context, ensure_byte_string(source))
         if not monitor:
-            raise EnvironmentError('Could not create udev monitor')
+            raise OSError('Could not create udev monitor')
         return cls(context, monitor)
 
     @property
@@ -133,7 +130,7 @@ class Monitor(object):
 
     def fileno(self):
         # pylint: disable=anomalous-backslash-in-string
-        """
+        r"""
         Return the file description associated with this monitor as integer.
 
         This is really a real file descriptor ;), which can be watched and
@@ -293,7 +290,7 @@ class Monitor(object):
             try:
                 device_p = self._libudev.udev_monitor_receive_device(self)
                 return Device(self.context, device_p) if device_p else None
-            except EnvironmentError as error:
+            except OSError as error:
                 if error.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
                     # No data available
                     return None
@@ -531,7 +528,7 @@ class MonitorObserver(Thread):
                     for device in iter(read_device, None):
                         self._callback(device)
                 else:
-                    raise EnvironmentError('Observed monitor hung up')
+                    raise OSError('Observed monitor hung up')
 
     def send_stop(self):
         """

--- a/src/pyudev/pyqt4.py
+++ b/src/pyudev/pyqt4.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012, 2013 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -16,7 +15,7 @@
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
 # pylint: disable=anomalous-backslash-in-string
-"""
+r"""
     pyudev.pyqt4
     ============
 
@@ -33,10 +32,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from PyQt4 import QtCore  # pylint: disable=import-error
 

--- a/src/pyudev/pyqt4.py
+++ b/src/pyudev/pyqt4.py
@@ -32,7 +32,6 @@ r"""
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-
 from PyQt4 import QtCore  # pylint: disable=import-error
 
 from ._qt_base import MonitorObserverGenerator

--- a/src/pyudev/pyqt5.py
+++ b/src/pyudev/pyqt5.py
@@ -28,7 +28,6 @@
     .. moduleauthor::  Tobias Gehring  <mail@tobiasgehring.de>
 """
 
-
 from PyQt5 import QtCore  # pylint: disable=import-error
 
 from ._qt_base import MonitorObserverGenerator

--- a/src/pyudev/pyqt5.py
+++ b/src/pyudev/pyqt5.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # This library is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License as published by the
 # Free Software Foundation; either version 2.1 of the License, or (at your
@@ -29,10 +28,6 @@
     .. moduleauthor::  Tobias Gehring  <mail@tobiasgehring.de>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from PyQt5 import QtCore  # pylint: disable=import-error
 

--- a/src/pyudev/pyside.py
+++ b/src/pyudev/pyside.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012, 2013 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -16,7 +15,7 @@
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
 # pylint: disable=anomalous-backslash-in-string
-"""
+r"""
     pyudev.pyside
     =============
 
@@ -34,10 +33,6 @@
     .. versionadded:: 0.6
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from PySide import QtCore  # pylint: disable=import-error
 

--- a/src/pyudev/pyside.py
+++ b/src/pyudev/pyside.py
@@ -33,7 +33,6 @@ r"""
     .. versionadded:: 0.6
 """
 
-
 from PySide import QtCore  # pylint: disable=import-error
 
 from ._qt_base import MonitorObserverGenerator

--- a/src/pyudev/version.py
+++ b/src/pyudev/version.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2015 mulhern <amulhern@redhat.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -24,5 +23,5 @@
 """
 
 __version_info__ = (0, 21, 0, '')
-__version__ = "%s%s" % (".".join(str(x) for x in __version_info__[:3]),
+__version__ = "{}{}".format(".".join(str(x) for x in __version_info__[:3]),
                         "".join(str(x) for x in __version_info__[3:]))

--- a/src/pyudev/version.py
+++ b/src/pyudev/version.py
@@ -24,4 +24,4 @@
 
 __version_info__ = (0, 21, 0, '')
 __version__ = "{}{}".format(".".join(str(x) for x in __version_info__[:3]),
-                        "".join(str(x) for x in __version_info__[3:]))
+                            "".join(str(x) for x in __version_info__[3:]))

--- a/src/pyudev/wx.py
+++ b/src/pyudev/wx.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Free Software Foundation; either version 2.1 of the License, or (at your
 # option) any later version.
 
@@ -12,7 +11,7 @@
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
 # pylint: disable=anomalous-backslash-in-string
-"""pyudev.wx
+r"""pyudev.wx
     =========
 
     Wx integration.
@@ -29,8 +28,6 @@
 
 """
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)
 
 from wx import EvtHandler, PostEvent
 from wx.lib.newevent import NewEvent  # pylint: disable=import-error, no-name-in-module

--- a/src/pyudev/wx.py
+++ b/src/pyudev/wx.py
@@ -28,7 +28,6 @@ r"""pyudev.wx
 
 """
 
-
 from wx import EvtHandler, PostEvent
 from wx.lib.newevent import NewEvent  # pylint: disable=import-error, no-name-in-module
 

--- a/tests/_constants.py
+++ b/tests/_constants.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2015 mulhern <amulhern@redhat.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -23,10 +22,6 @@
     .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from hypothesis import strategies
 

--- a/tests/_constants.py
+++ b/tests/_constants.py
@@ -22,7 +22,6 @@
     .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-
 from hypothesis import strategies
 
 import pytest

--- a/tests/_device_tests/__init__.py
+++ b/tests/_device_tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2015 mulhern <amulhern@redhat.com>
 
 # This library is free software; you can redistribute it and/or modify it

--- a/tests/_device_tests/_attributes_tests.py
+++ b/tests/_device_tests/_attributes_tests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -20,10 +19,6 @@ Tests methods belonging to Attributes class.
 .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import os
 import stat
@@ -44,7 +39,7 @@ from ._device_tests import _DEVICES
 from ._device_tests import _UDEV_TEST
 
 
-class TestAttributes(object):
+class TestAttributes:
     """
     Test ``Attributes`` class methods.
     """

--- a/tests/_device_tests/_attributes_tests.py
+++ b/tests/_device_tests/_attributes_tests.py
@@ -19,7 +19,6 @@ Tests methods belonging to Attributes class.
 .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-
 import os
 import stat
 

--- a/tests/_device_tests/_device_tests.py
+++ b/tests/_device_tests/_device_tests.py
@@ -19,7 +19,6 @@ Tests methods belonging to Device class.
 .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-
 import re
 import os
 import operator

--- a/tests/_device_tests/_device_tests.py
+++ b/tests/_device_tests/_device_tests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -20,10 +19,6 @@ Tests methods belonging to Device class.
 .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import re
 import os
@@ -52,7 +47,7 @@ from .._constants import _DEVICES
 from .._constants import _UDEV_TEST
 
 
-class TestDevice(object):
+class TestDevice:
     """
     Test ``Device`` methods.
     """
@@ -479,7 +474,7 @@ class TestDevice(object):
         https://bugzilla.redhat.com/show_bug.cgi?id=1263441.
         """
         id_wwn = a_device.properties['ID_WWN_WITH_EXTENSION']
-        assert a_device.subsystem == u'block'
+        assert a_device.subsystem == 'block'
 
         id_path = '/dev/disk/by-id'
         link_name = "wwn-%s" % id_wwn

--- a/tests/_device_tests/_devices_tests.py
+++ b/tests/_device_tests/_devices_tests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -20,10 +19,6 @@ Tests methods belonging to Devices class.
 .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import os
 import stat
@@ -50,7 +45,7 @@ from .._constants import device_strategy
 from ..utils import failed_health_check_wrapper
 
 
-class TestDevices(object):
+class TestDevices:
     """
     Test ``Devices`` methods.
     """

--- a/tests/_device_tests/_devices_tests.py
+++ b/tests/_device_tests/_devices_tests.py
@@ -19,7 +19,6 @@ Tests methods belonging to Devices class.
 .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-
 import os
 import stat
 

--- a/tests/_device_tests/_tags_tests.py
+++ b/tests/_device_tests/_tags_tests.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -20,10 +19,6 @@ Tests methods belonging to Devices class.
 .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from hypothesis import given
 from hypothesis import settings
@@ -42,7 +37,7 @@ from ._device_tests import _DEVICES
 from ._device_tests import _UDEV_TEST
 
 
-class TestTags(object):
+class TestTags:
     """
     Test methods of the ``Tags`` class.
     """

--- a/tests/_device_tests/_tags_tests.py
+++ b/tests/_device_tests/_tags_tests.py
@@ -19,7 +19,6 @@ Tests methods belonging to Devices class.
 .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-
 from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-
 import pytest
 
 import pyudev

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012, 2013 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -15,18 +14,16 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)
 
 import pytest
 
 import pyudev
 
 pytest_plugins = [
-    str('tests.plugins.fake_monitor'),
-    str('tests.plugins.privileged'),
-    str('tests.plugins.mock_libudev'),
-    str('tests.plugins.travis'),
+    'tests.plugins.fake_monitor',
+    'tests.plugins.privileged',
+    'tests.plugins.mock_libudev',
+    'tests.plugins.travis',
 ]
 
 

--- a/tests/plugins/__init__.py
+++ b/tests/plugins/__init__.py
@@ -21,4 +21,3 @@
 
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
-

--- a/tests/plugins/__init__.py
+++ b/tests/plugins/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2012 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -23,5 +22,3 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)

--- a/tests/plugins/fake_monitor.py
+++ b/tests/plugins/fake_monitor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2012 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -28,8 +27,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)
 
 import os
 from select import select
@@ -37,7 +34,7 @@ from select import select
 import pytest
 
 
-class FakeMonitor(object):
+class FakeMonitor:
     """
     A fake :class:`~pyudev.Monitor` which allows you to trigger arbitrary
     events.

--- a/tests/plugins/fake_monitor.py
+++ b/tests/plugins/fake_monitor.py
@@ -27,7 +27,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-
 import os
 from select import select
 

--- a/tests/plugins/mock_libudev.py
+++ b/tests/plugins/mock_libudev.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2012 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -25,8 +24,6 @@
 
 """
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)
 
 from operator import attrgetter
 from contextlib import contextmanager
@@ -38,7 +35,7 @@ import mock
 Node = namedtuple('Node', 'name value next')
 
 
-class LinkedList(object):
+class LinkedList:
     """
     Linked list class to mock libudev list functions.
     """
@@ -81,7 +78,7 @@ def libudev_list(libudev, function, items):
         function, 'udev_list_entry_get_next', 'udev_list_entry_get_name',
         'udev_list_entry_get_value'
     ]
-    mocks = dict((f, mock.DEFAULT) for f in functions_to_patch)
+    mocks = {f: mock.DEFAULT for f in functions_to_patch}
     with mock.patch.multiple(libudev, **mocks):
         udev_list = LinkedList.from_iterable(items)
         getattr(libudev, function).return_value = udev_list.first

--- a/tests/plugins/mock_libudev.py
+++ b/tests/plugins/mock_libudev.py
@@ -24,7 +24,6 @@
 
 """
 
-
 from operator import attrgetter
 from contextlib import contextmanager
 from collections import namedtuple

--- a/tests/plugins/privileged.py
+++ b/tests/plugins/privileged.py
@@ -25,7 +25,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-
 from subprocess import call
 
 import pytest

--- a/tests/plugins/privileged.py
+++ b/tests/plugins/privileged.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2012 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -26,8 +25,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)
 
 from subprocess import call
 

--- a/tests/plugins/travis.py
+++ b/tests/plugins/travis.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2013 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -15,8 +14,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)
 
 import random
 import syslog
@@ -38,7 +35,7 @@ def test_udev_version():
     assert udev_version() > 150
 
 
-class TestContext(object):
+class TestContext:
     def test_sys_path(self, context):
         assert is_unicode_string(context.sys_path)
         assert context.sys_path == '/sys'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,7 +14,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-
 import random
 import syslog
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -23,8 +22,6 @@
     .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)
 
 import gc
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -22,7 +22,6 @@
     .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-
 import gc
 
 # pylint: disable=unused-import

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -36,6 +36,6 @@ def test_garbage():
     Make sure that all the device tests create no uncollectable objects.
 
     This test must stick at the bottom of this test file to make sure that
-    ``py.test`` always executes it at last.
+    ``pytest`` always executes it at last.
     """
     assert not gc.garbage

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2015 Anne Mulhern <amulhern@redhat.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -23,10 +22,6 @@
     .. moduleauthor:: mulhern <amulhern@redhat.com>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import os
 
@@ -51,7 +46,7 @@ _DEVICES = [d for d in _CONTEXT.list_devices()]
 NUM_TESTS = 5
 
 
-class TestUtilities(object):
+class TestUtilities:
     """
     Some utilities used by the actual tests.
     """
@@ -69,7 +64,7 @@ class TestUtilities(object):
         device_number = a_device.device_number
         major_number = os.major(device_number)
         minor_number = os.minor(device_number)
-        pair_number = "%s%s%s" % (major_number, a_string, minor_number)
+        pair_number = "{}{}{}".format(major_number, a_string, minor_number)
         return (str(device_number), pair_number)
 
     @staticmethod
@@ -104,7 +99,7 @@ class TestUtilities(object):
         return links
 
 
-class TestDiscovery(object):
+class TestDiscovery:
     """
     Test discovery of an object from limited bits of its description.
     """
@@ -136,7 +131,7 @@ class TestDiscovery(object):
         """
         for path in TestUtilities.get_paths(a_device):
             res = DevicePathHypothesis.get_devices(self._CONTEXT, path)
-            assert res == set((a_device, ))
+            assert res == {a_device}
 
     @given(strategies.sampled_from(_DEVICES))
     @settings(max_examples=NUM_TESTS)

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -22,7 +22,6 @@
     .. moduleauthor:: mulhern <amulhern@redhat.com>
 """
 
-
 import os
 
 import pyudev

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -15,8 +14,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)
 
 import mock
 
@@ -79,7 +76,7 @@ def _test_intersection_and_union(context, matches, nomatches):
     assert matches | nomatches == frozenset(context.list_devices())
 
 
-class TestEnumerator(object):
+class TestEnumerator:
     """
     Test the Enumerator class.
     """
@@ -228,7 +225,7 @@ class TestEnumerator(object):
         assert device in children
 
 
-class TestEnumeratorMatchCombinations(object):
+class TestEnumeratorMatchCombinations:
     """
     Test combinations of matches.
     """
@@ -312,7 +309,7 @@ class TestEnumeratorMatchCombinations(object):
         )
 
 
-class TestEnumeratorMatchMethod(object):
+class TestEnumeratorMatchMethod:
     """
     Test the behavior of Enumerator.match.
 

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -14,7 +14,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-
 import mock
 
 from hypothesis import given

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012, 2013 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -15,8 +14,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)
 import random
 
 from datetime import datetime, timedelta
@@ -53,7 +50,7 @@ def fake_monitor_device(request):
 
 @contextmanager
 def patch_filter_by(type):
-    add_match = 'udev_monitor_filter_add_match_{0}'.format(type)
+    add_match = 'udev_monitor_filter_add_match_{}'.format(type)
     filter_update = 'udev_monitor_filter_update'
     with pytest.patch_libudev(add_match) as add_match:
         add_match.return_value = 0
@@ -62,11 +59,11 @@ def patch_filter_by(type):
             yield add_match, filter_update
 
 
-class TestMonitor(object):
+class TestMonitor:
     def test_from_netlink_invalid_source(self, context):
         with pytest.raises(ValueError) as exc_info:
             Monitor.from_netlink(context, source='invalid_source')
-        message = ('Invalid source: {0!r}. Must be one of "udev" '
+        message = ('Invalid source: {!r}. Must be one of "udev" '
                    'or "kernel"'.format('invalid_source'))
         assert str(exc_info.value) == message
 
@@ -296,7 +293,7 @@ class TestMonitor(object):
         iterator.close()
 
 
-class TestMonitorObserver(object):
+class TestMonitorObserver:
     def callback(self, device):
         self.events.append(device)
         if len(self.events) >= 2:

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012, 2013 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -15,8 +14,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)
 
 import random
 
@@ -50,7 +47,7 @@ def test_fake_monitor(fake_monitor, fake_monitor_device):
     assert device == fake_monitor_device
 
 
-class ObserverTestBase(object):
+class ObserverTestBase:
     def setup_method(self, method):
         self.observer = None
         self.no_emitted_signals = 0
@@ -128,12 +125,12 @@ class ObserverTestBase(object):
 
 class QtObserverTestBase(ObserverTestBase):
     def setup(self):
-        self.qtcore = pytest.importorskip('{0}.QtCore'.format(
+        self.qtcore = pytest.importorskip('{}.QtCore'.format(
             self.BINDING_NAME))
 
     def create_observer(self, monitor):
         name = self.BINDING_NAME.lower()
-        mod = __import__('pyudev.{0}'.format(name), None, None, [name])
+        mod = __import__('pyudev.{}'.format(name), None, None, [name])
         self.observer = mod.MonitorObserver(monitor)
 
     def connect_signal(self, callback):
@@ -206,7 +203,7 @@ class TestGlibObserver(ObserverTestBase):
 
 
 @pytest.mark.skipif(
-    str('"DISPLAY" not in os.environ'), reason='Display required for wxPython')
+    '"DISPLAY" not in os.environ', reason='Display required for wxPython')
 class TestWxObserver(ObserverTestBase):
     def setup(self):
         self.wx = pytest.importorskip('wx')

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -14,7 +14,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-
 import random
 
 import pytest

--- a/tests/test_observer_deprecated.py
+++ b/tests/test_observer_deprecated.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012, 2013 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -15,8 +14,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)
 
 import pytest
 import mock
@@ -38,7 +35,7 @@ def fake_monitor_device(request):
 ACTIONS = ('add', 'remove', 'change', 'move')
 
 
-class DeprecatedObserverTestBase(object):
+class DeprecatedObserverTestBase:
     def setup_method(self, method):
         self.observer = None
         self.no_emitted_signals = 0
@@ -146,12 +143,12 @@ class DeprecatedQtObserverTestBase(DeprecatedObserverTestBase):
     }
 
     def setup(self):
-        self.qtcore = pytest.importorskip('{0}.QtCore'.format(
+        self.qtcore = pytest.importorskip('{}.QtCore'.format(
             self.BINDING_NAME))
 
     def create_observer(self, monitor):
         name = self.BINDING_NAME.lower()
-        mod = __import__('pyudev.{0}'.format(name), None, None, [name])
+        mod = __import__('pyudev.{}'.format(name), None, None, [name])
         self.observer = mod.QUDevMonitorObserver(monitor)
 
     def connect_signal(self, callback, action=None):
@@ -235,7 +232,7 @@ class TestDeprecatedGlibObserver(DeprecatedObserverTestBase):
 
 
 @pytest.mark.skipif(
-    str('"DISPLAY" not in os.environ'), reason='Display required for wxPython')
+    '"DISPLAY" not in os.environ', reason='Display required for wxPython')
 class TestDeprecatedWxObserver(DeprecatedObserverTestBase):
     def setup(self):
         self.wx = pytest.importorskip('wx')

--- a/tests/test_observer_deprecated.py
+++ b/tests/test_observer_deprecated.py
@@ -14,7 +14,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-
 import pytest
 import mock
 

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -19,9 +19,6 @@ import re
 import os
 import subprocess
 from distutils.filelist import FileList
-if sys.version_info[0] < 3:
-    from codecs import open
-    from urlparse import urlparse
 
 import py.path
 import pytest
@@ -162,10 +159,3 @@ def test_manifest_complete():
     required_files = sorted(_get_required_files())
     included_files = sorted(_get_manifest_files())
     assert required_files == included_files
-
-
-@pytest.mark.skipif('sys.version_info[0] > 2')
-def test_description_rendering():
-    with open(README, 'r', encoding='utf-8') as source:
-        output = render_readme_like_pypi(source.read())
-    assert output

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -14,7 +14,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-
 import sys
 import re
 import os

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012, 2013 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -15,8 +14,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)
 
 import sys
 import re
@@ -140,7 +137,7 @@ def render_readme_like_pypi(source, output_encoding='unicode'):
             continue
         o = urlparse(uri)
         if o.scheme not in ALLOWED_SCHEMES:
-            raise TransformError('link scheme not allowed: {0}'.format(uri))
+            raise TransformError('link scheme not allowed: {}'.format(uri))
 
     # now turn the transformed document into HTML
     reader = readers.doctree.Reader(parser_name='null')
@@ -168,7 +165,7 @@ def test_manifest_complete():
     assert required_files == included_files
 
 
-@pytest.mark.skipif(str('sys.version_info[0] > 2'))
+@pytest.mark.skipif('sys.version_info[0] > 2')
 def test_description_rendering():
     with open(README, 'r', encoding='utf-8') as source:
         output = render_readme_like_pypi(source.read())

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -14,7 +14,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-
 import sys
 
 import pytest

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2010, 2011, 2012 Sebastian Wiesner <lunaryorn@gmail.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -15,8 +14,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-from __future__ import (print_function, division, unicode_literals,
-                        absolute_import)
 
 import sys
 
@@ -101,7 +98,7 @@ def test_string_to_bool_false():
 def test_string_to_bool_invalid_value():
     with pytest.raises(ValueError) as exc_info:
         _util.string_to_bool('foo')
-    assert str(exc_info.value) == 'Not a boolean value: {0!r}'.format('foo')
+    assert str(exc_info.value) == 'Not a boolean value: {!r}'.format('foo')
 
 
 def test_udev_list_iterate_no_entry():
@@ -152,7 +149,7 @@ def test_get_device_type_no_device_file(tmpdir):
     filename.ensure(file=True)
     with pytest.raises(ValueError) as excinfo:
         _util.get_device_type(str(filename))
-    message = 'not a device file: {0!r}'.format(str(filename))
+    message = 'not a device file: {!r}'.format(str(filename))
     assert str(excinfo.value) == message
 
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2015 mulhern <amulhern@redhat.com>
 
 # This library is free software; you can redistribute it and/or modify it

--- a/tests/utils/misc.py
+++ b/tests/utils/misc.py
@@ -24,8 +24,6 @@
 
 from functools import wraps
 
-import six
-
 import pytest
 
 from hypothesis.core import FailedHealthCheck
@@ -34,9 +32,9 @@ from hypothesis.core import FailedHealthCheck
 def is_unicode_string(value):
     """
     Return ``True``, if ``value`` is of a real unicode string type
-    (``unicode`` in python 2, ``str`` in python 3), ``False`` otherwise.
+    (``str``), ``False`` otherwise.
     """
-    return isinstance(value, unicode if six.PY2 else str)
+    return isinstance(value, str)
 
 
 def failed_health_check_wrapper(func):

--- a/tests/utils/misc.py
+++ b/tests/utils/misc.py
@@ -22,7 +22,6 @@
     .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-
 from functools import wraps
 
 import six

--- a/tests/utils/misc.py
+++ b/tests/utils/misc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2015 mulhern <amulhern@redhat.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -23,10 +22,6 @@
     .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 from functools import wraps
 
@@ -58,7 +53,7 @@ def failed_health_check_wrapper(func):
         try:
             func(*args)
         except FailedHealthCheck:
-            func_code = six.get_function_code(func)
+            func_code = func.__code__
             pytest.skip(
                'failed health check for %s() (%s: %s)' % \
                (

--- a/tests/utils/udev.py
+++ b/tests/utils/udev.py
@@ -24,7 +24,6 @@
     .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-
 import sys
 import os
 import re

--- a/tests/utils/udev.py
+++ b/tests/utils/udev.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2015 mulhern <amulhern@redhat.com>
 
 # This library is free software; you can redistribute it and/or modify it
@@ -25,10 +24,6 @@
     .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import sys
 import os
@@ -38,7 +33,7 @@ import subprocess
 from collections import Iterable, Sized
 
 
-class UDevAdm(object):
+class UDevAdm:
     """
     Wrap ``udevadm`` utility.
     """
@@ -62,7 +57,7 @@ class UDevAdm(object):
                 # executable
                 udevadm.query_udev_version()
                 return udevadm
-            except EnvironmentError as error:
+            except OSError as error:
                 if error.errno != errno.ENOENT:
                     raise
 
@@ -77,7 +72,7 @@ class UDevAdm(object):
         if cls._adm is None:
             try:
                 cls._adm = cls.find()
-            except EnvironmentError:
+            except OSError:
                 pass
         return cls._adm
 
@@ -187,7 +182,7 @@ class UDevAdm(object):
             return None
 
 
-class DeviceData(object):
+class DeviceData:
     """
     Data for a single device.
     """
@@ -197,7 +192,7 @@ class DeviceData(object):
         self._udevadm = udevadm
 
     def __repr__(self):
-        return '{0}({1})'.format(self.__class__.__name__, self.device_path)
+        return '{}({})'.format(self.__class__.__name__, self.device_path)
 
     @property
     def sys_path(self):

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,8 @@ deps=
     coverage
     hypothesis
 commands=
-    py.test {posargs:--junitxml={envname}-tests.xml -rsx}
-    coverage run --timid --branch -m py.test {posargs:--junitxml={envname}-tests.xml}
+    pytest {posargs:--junitxml={envname}-tests.xml -rsx}
+    coverage run --timid --branch -m pytest {posargs:--junitxml={envname}-tests.xml}
     coverage report --include="{envsitepackagesdir}/pyudev/*"
     coverage html --include="{envsitepackagesdir}/pyudev/*"
 


### PR DESCRIPTION
Fixes https://github.com/pyudev/pyudev/issues/380.

---

Should EOL Python 3.1-3.4 also be dropped?

Version | Release date | Supported until
--- | ---------- | ----------
2.6 | 2008-10-01 | 2013-10-29
2.7 | 2010-07-03 | 2020-01-01
3.0 | 2008-12-03 | 2009-06-27
3.1 | 2009-06-27 | 2012-04-09
3.2 | 2011-02-20 | 2016-02-27
3.3 | 2012-09-29 | 2017-09-29
3.4 | 2014-03-16 | 2019-03-16

Source: https://en.wikipedia.org/wiki/CPython#Version_history
