### PR TITLE
Enable GLib unit tests

### DIFF
--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -146,9 +146,8 @@ class TestPyQt5Observer(QtObserverTestBase):
 class TestGlibObserver(ObserverTestBase):
     def setup(self):
         self.event_sources = []
-        self.glib = pytest.importorskip('glib')
-        # make sure that we also have gobject
-        pytest.importorskip('gobject')
+        pytest.importorskip('gi')
+        self.glib = pytest.importorskip('gi.repository.GLib')
 
     def teardown(self):
         for source in self.event_sources:

--- a/tests/test_observer_deprecated.py
+++ b/tests/test_observer_deprecated.py
@@ -164,9 +164,8 @@ class TestDeprecatedGlibObserver(DeprecatedObserverTestBase):
 
     def setup(self):
         self.event_sources = []
-        self.glib = pytest.importorskip('glib')
-        # make sure that we also have gobject
-        pytest.importorskip('gobject')
+        pytest.importorskip('gi')
+        self.glib = pytest.importorskip('gi.repository.GLib')
 
     def teardown(self):
         for source in self.event_sources:

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps=
     mock>=1.0b1
     coverage
     hypothesis
+    PyGObject
 commands=
     py.test {posargs:--junitxml={envname}-tests.xml -rsx}
     coverage run --timid --branch -m py.test {posargs:--junitxml={envname}-tests.xml}


### PR DESCRIPTION
Enable unittests for the glib observer and update unit tests to new style gi.repository.GLib imports. Related to PR #399 