### PR TITLE
[#367] Fixes obscure deprecation warning for bool comp

### DIFF
--- a/src/pyudev/device/_device.py
+++ b/src/pyudev/device/_device.py
@@ -918,7 +918,10 @@ class Device(collections_abc.Mapping):
         """
         import warnings
         warnings.warn(
-            'Will be removed in 1.0. Access properties with Device.properties.',
+            ('Will be removed in 1.0. '
+            'Access number of properties with len(Device.properties). '
+            'If the Device does not exist, explicitly comparing against '
+            'None will remove this warning.'),
             DeprecationWarning,
             stacklevel=2)
         return self.properties.__len__()


### PR DESCRIPTION
- Changes the warning string but splits it over multiple lines to avoid the line too long lint error