### PR TITLE
remove external mock dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # unit test requirements
 docutils>=0.9
 pytest>=2.8
-mock>=1.0b1
+mock>=1.0b1; python_version < "3.3"
 hypothesis==4.11.7
 
 # documentation requirements

--- a/tests/_device_tests/_device_tests.py
+++ b/tests/_device_tests/_device_tests.py
@@ -36,7 +36,10 @@ from hypothesis import settings
 from hypothesis import strategies
 
 import pytest
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from pyudev import Device
 from pyudev import Devices

--- a/tests/_device_tests/_tags_tests.py
+++ b/tests/_device_tests/_tags_tests.py
@@ -30,7 +30,10 @@ from hypothesis import settings
 from hypothesis import strategies
 
 import pytest
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from pyudev import Devices
 

--- a/tests/plugins/mock_libudev.py
+++ b/tests/plugins/mock_libudev.py
@@ -33,7 +33,10 @@ from contextlib import contextmanager
 from collections import namedtuple
 
 import pytest
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 Node = namedtuple('Node', 'name value next')
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -21,7 +21,10 @@ from __future__ import (print_function, division, unicode_literals,
 import random
 import syslog
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from pyudev import udev_version
 

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -18,7 +18,10 @@
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from hypothesis import given
 from hypothesis import settings

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -24,7 +24,10 @@ from contextlib import contextmanager
 from select import select
 
 import pytest
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from pyudev import Monitor, MonitorObserver, Devices
 

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -21,7 +21,10 @@ from __future__ import (print_function, division, unicode_literals,
 import random
 
 import pytest
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from pyudev import Monitor, Devices
 

--- a/tests/test_observer_deprecated.py
+++ b/tests/test_observer_deprecated.py
@@ -19,7 +19,10 @@ from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 
 import pytest
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from pyudev import Monitor, Devices
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -21,7 +21,10 @@ from __future__ import (print_function, division, unicode_literals,
 import sys
 
 import pytest
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from hypothesis import given
 from hypothesis import settings

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ setenv=LD_LIBRARY_PATH={envdir}/lib
 deps=
     docutils>=0.9
     pytest>=3.0
-    mock>=1.0b1
+    mock>=1.0b1; python_version < "3.3"
     coverage
     hypothesis
     PyGObject
@@ -19,7 +19,7 @@ commands=
 [testenv:doc]
 downloadcache={toxworkdir}/_download
 deps=
-    mock>=1.0b1
+    mock>=1.0b1; python_version < "3.3"
     pytest>=2.8
     sphinx>=1.0.7
 commands=


### PR DESCRIPTION
Mock is included in the Python standard library >= 3.3. Remove the external pull for those versions.