### PR TITLE
Library find function fallback

### DIFF
--- a/src/pyudev/_ctypeslib/utils.py
+++ b/src/pyudev/_ctypeslib/utils.py
@@ -51,7 +51,10 @@ def load_ctypes_library(name, signatures, error_checkers):
     """
     library_name = find_library(name)
     if not library_name:
-        raise ImportError("No library named %s" % name)
+        try:
+            CDLL("libudev.so")
+        except OSError:
+            raise ImportError("No library named %s" % name)
     lib = CDLL(library_name, use_errno=True)
     # Add function signatures
     for funcname, signature in signatures.items():


### PR DESCRIPTION
If find_library return None, Try CDLL import.

This commit will fix find_library funtion issue. 
https://github.com/pyudev/pyudev/issues/108 or https://github.com/pyudev/pyudev/issues/83

I am not removing any function I just added fallback.