### PR TITLE
Escape backslashes

### DIFF
--- a/src/pyudev/monitor.py
+++ b/src/pyudev/monitor.py
@@ -133,12 +133,11 @@ class Monitor(object):
         return self._started
 
     def fileno(self):
-        # pylint: disable=anomalous-backslash-in-string
         """
         Return the file description associated with this monitor as integer.
 
         This is really a real file descriptor ;), which can be watched and
-        :func:`select.select`\ ed.
+        :func:`select.select`\\ ed.
         """
         return self._libudev.udev_monitor_get_fd(self)
 

--- a/src/pyudev/pyqt4.py
+++ b/src/pyudev/pyqt4.py
@@ -15,17 +15,16 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-# pylint: disable=anomalous-backslash-in-string
 """
     pyudev.pyqt4
     ============
 
     PyQt4 integration.
 
-    :class:`MonitorObserver` integrates device monitoring into the PyQt4\_
+    :class:`MonitorObserver` integrates device monitoring into the PyQt4\\_
     mainloop by turning device events into Qt signals.
 
-    :mod:`PyQt4.QtCore` from PyQt4\_ must be available when importing this
+    :mod:`PyQt4.QtCore` from PyQt4\\_ must be available when importing this
     module.
 
     .. _PyQt4: http://riverbankcomputing.co.uk/software/pyqt/intro

--- a/src/pyudev/pyside.py
+++ b/src/pyudev/pyside.py
@@ -15,17 +15,16 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-# pylint: disable=anomalous-backslash-in-string
 """
     pyudev.pyside
     =============
 
     PySide integration.
 
-    :class:`QUDevMonitorObserver` integrates device monitoring into the PySide\_
-    mainloop by turing device events into Qt signals.
+    :class:`QUDevMonitorObserver` integrates device monitoring into the
+    PySide\\_ mainloop by turing device events into Qt signals.
 
-    :mod:`PySide.QtCore` from PySide\_ must be available when importing this
+    :mod:`PySide.QtCore` from PySide\\_ must be available when importing this
     module.
 
     .. _PySide: http://www.pyside.org

--- a/src/pyudev/wx.py
+++ b/src/pyudev/wx.py
@@ -11,16 +11,15 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-# pylint: disable=anomalous-backslash-in-string
 """pyudev.wx
     =========
 
     Wx integration.
 
-    :class:`MonitorObserver` integrates device monitoring into the wxPython\_
+    :class:`MonitorObserver` integrates device monitoring into the wxPython\\_
     mainloop by turing device events into wx events.
 
-    :mod:`wx` from wxPython\_ must be available when importing this module.
+    :mod:`wx` from wxPython\\_ must be available when importing this module.
 
     .. _wxPython: http://wxpython.org/
 


### PR DESCRIPTION
Resolve the following warnings seen when pyudev is used in more recent versions of Python.

    .../pyudev/monitor.py:137: DeprecationWarning: invalid escape sequence
      \
