### PR TITLE
Python 2 removal cleanup

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,9 +15,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-
-from __future__ import print_function, division, unicode_literals, absolute_import
-
 import sys
 import os
 

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setuptools.setup(
     long_description_content_type="text/x-rst",
     platforms=["Linux"],
     license="LGPL 2.1+",
+    python_requires=">=3.7",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/src/pyudev/__init__.py
+++ b/src/pyudev/__init__.py
@@ -32,9 +32,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: LOCAL
 from pyudev._errors import (
     DeviceNotFoundAtPathError,

--- a/src/pyudev/_ctypeslib/_errorcheckers.py
+++ b/src/pyudev/_ctypeslib/_errorcheckers.py
@@ -21,9 +21,6 @@
     Error checkers for ctypes wrappers.
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import errno
 import os

--- a/src/pyudev/_ctypeslib/libc.py
+++ b/src/pyudev/_ctypeslib/libc.py
@@ -23,9 +23,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 from ctypes import c_int
 

--- a/src/pyudev/_ctypeslib/libudev.py
+++ b/src/pyudev/_ctypeslib/libudev.py
@@ -24,9 +24,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 from ctypes import POINTER, Structure, c_char, c_char_p, c_int, c_uint, c_ulonglong
 

--- a/src/pyudev/_ctypeslib/utils.py
+++ b/src/pyudev/_ctypeslib/utils.py
@@ -23,9 +23,6 @@
     .. moduleauthor::  Anne Mulhern  <amulhern@redhat.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 from ctypes import CDLL
 from ctypes.util import find_library

--- a/src/pyudev/_errors.py
+++ b/src/pyudev/_errors.py
@@ -23,9 +23,6 @@
     .. moduleauthor:: Sebastian Wiesner <lunaryorn@gmail.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import abc
 

--- a/src/pyudev/_os/pipe.py
+++ b/src/pyudev/_os/pipe.py
@@ -29,9 +29,6 @@
     .. moduleauthor:: Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import fcntl
 import os

--- a/src/pyudev/_os/poll.py
+++ b/src/pyudev/_os/poll.py
@@ -23,9 +23,6 @@
     .. moduleauthor:: Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import select
 

--- a/src/pyudev/_qt_base.py
+++ b/src/pyudev/_qt_base.py
@@ -23,9 +23,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: LOCAL
 from pyudev.device import Device
 

--- a/src/pyudev/_util.py
+++ b/src/pyudev/_util.py
@@ -23,9 +23,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import errno
 import os

--- a/src/pyudev/core.py
+++ b/src/pyudev/core.py
@@ -23,9 +23,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: LOCAL
 from pyudev._ctypeslib.libudev import ERROR_CHECKERS, SIGNATURES
 from pyudev._ctypeslib.utils import load_ctypes_library

--- a/src/pyudev/device/_device.py
+++ b/src/pyudev/device/_device.py
@@ -23,9 +23,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import collections
 import os

--- a/src/pyudev/discover.py
+++ b/src/pyudev/discover.py
@@ -23,9 +23,6 @@
     .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import abc
 import functools

--- a/src/pyudev/glib.py
+++ b/src/pyudev/glib.py
@@ -32,9 +32,6 @@
 
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: THIRDPARTY
 from gi.repository import GLib, GObject  # pylint: disable=import-error
 

--- a/src/pyudev/monitor.py
+++ b/src/pyudev/monitor.py
@@ -23,9 +23,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import errno
 import os

--- a/src/pyudev/pyqt4.py
+++ b/src/pyudev/pyqt4.py
@@ -32,9 +32,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: THIRDPARTY
 from PyQt4 import QtCore  # pylint: disable=import-error
 

--- a/src/pyudev/pyqt5.py
+++ b/src/pyudev/pyqt5.py
@@ -29,9 +29,6 @@
     .. moduleauthor::  Tobias Gehring  <mail@tobiasgehring.de>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: THIRDPARTY
 from PyQt5 import QtCore  # pylint: disable=import-error
 

--- a/src/pyudev/pyside.py
+++ b/src/pyudev/pyside.py
@@ -33,9 +33,6 @@
     .. versionadded:: 0.6
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: THIRDPARTY
 from PySide import QtCore  # pylint: disable=import-error
 

--- a/src/pyudev/wx.py
+++ b/src/pyudev/wx.py
@@ -28,9 +28,6 @@
 
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: THIRDPARTY
 from wx import EvtHandler, PostEvent  # pylint: disable=import-error
 from wx.lib.newevent import NewEvent  # pylint: disable=import-error, no-name-in-module

--- a/tests/_constants.py
+++ b/tests/_constants.py
@@ -23,9 +23,6 @@
     .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: THIRDPARTY
 import pytest
 from hypothesis import strategies

--- a/tests/_device_tests/_attributes_tests.py
+++ b/tests/_device_tests/_attributes_tests.py
@@ -20,9 +20,6 @@ Tests methods belonging to Attributes class.
 .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import os
 import stat

--- a/tests/_device_tests/_device_tests.py
+++ b/tests/_device_tests/_device_tests.py
@@ -20,9 +20,6 @@ Tests methods belonging to Device class.
 .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import gc
 import operator

--- a/tests/_device_tests/_devices_tests.py
+++ b/tests/_device_tests/_devices_tests.py
@@ -20,9 +20,6 @@ Tests methods belonging to Devices class.
 .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import os
 import stat

--- a/tests/_device_tests/_tags_tests.py
+++ b/tests/_device_tests/_tags_tests.py
@@ -20,9 +20,6 @@ Tests methods belonging to Devices class.
 .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: THIRDPARTY
 import pytest
 from hypothesis import given, settings, strategies

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: THIRDPARTY
 import pytest
 

--- a/tests/plugins/__init__.py
+++ b/tests/plugins/__init__.py
@@ -22,6 +22,3 @@
 
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
-
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals

--- a/tests/plugins/fake_monitor.py
+++ b/tests/plugins/fake_monitor.py
@@ -27,9 +27,6 @@
     .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import os
 from select import select

--- a/tests/plugins/mock_libudev.py
+++ b/tests/plugins/mock_libudev.py
@@ -25,9 +25,6 @@
 
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 from collections import namedtuple
 from contextlib import contextmanager

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -15,9 +15,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import random
 import syslog

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -23,9 +23,6 @@
     .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import gc
 

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -23,9 +23,6 @@
     .. moduleauthor:: mulhern <amulhern@redhat.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import os
 

--- a/tests/test_enumerate.py
+++ b/tests/test_enumerate.py
@@ -15,9 +15,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: THIRDPARTY
 from hypothesis import given, settings, strategies
 

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -15,9 +15,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import random
 from contextlib import contextmanager

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -15,9 +15,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import random
 

--- a/tests/test_observer_deprecated.py
+++ b/tests/test_observer_deprecated.py
@@ -15,9 +15,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: THIRDPARTY
 import pytest
 

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -15,9 +15,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import os
 import re

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -193,12 +193,6 @@ def test_eintr_retry_call(tmpdir):
     try:
         signal.signal(signal.SIGALRM, handle_alarm)
 
-        # Ensure that a signal raises EINTR on Python < 3.5
-        if sys.version_info < (3, 5):
-            with pytest.raises(select.error):
-                signal.alarm(1)
-                select.select([], [], [fd], 2)
-
         # Ensure that wrapping the call does not raise EINTR
         signal.alarm(1)
         assert _util.eintr_retry_call(select.select, [], [], [3], 2) == ([], [], [])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -15,9 +15,6 @@
 # along with this library; if not, write to the Free Software Foundation,
 # Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import sys
 

--- a/tests/utils/misc.py
+++ b/tests/utils/misc.py
@@ -23,9 +23,6 @@
     .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 from functools import wraps
 

--- a/tests/utils/udev.py
+++ b/tests/utils/udev.py
@@ -25,9 +25,6 @@
     .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-# isort: FUTURE
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 # isort: STDLIB
 import collections
 import errno


### PR DESCRIPTION
Couple of small tweaks.

- Indicate that package only supports Python 3
- Remove unnecessary __future__ imports
- Remove test for EOL version of Python 3

Closes #463 
