### PR TITLE
Support pytest 8 changes.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,15 +19,15 @@ jobs:
         include:
           # MANDATORY CHECKS USING CURRENT DEVELOPMENT INTERPRETER
           - python-version: "3.12"
-            dependencies: pytest=="7" hypothesis
+            dependencies: pytest hypothesis
             task: PYTHONPATH=./src make -f Makefile test-travis
           # MANDATORY CHECKS USING LOWEST SUPPORTED INTERPRETER
           - python-version: "3.10"
-            dependencies: pytest=="7" hypothesis
+            dependencies: pytest hypothesis
             task: PYTHONPATH=./src make -f Makefile test-travis
           # MANDATORY CHECKS USING PYPY INTERPRETER
           - python-version: pypy-3.9
-            dependencies: pytest=="7" hypothesis
+            dependencies: pytest hypothesis
             task: PYTHONPATH=./src make -f Makefile test-travis
     runs-on: ubuntu-latest
     steps:

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -277,10 +277,10 @@ class TestMonitorObserver:
             self.observer = MonitorObserver(monitor, callback=self.callback)
         return self.observer
 
-    def setup(self):
+    def setup_method(self):
         self.events = []
 
-    def teardown(self):
+    def teardown_method(self):
         self.events = None
 
     def test_deprecated_handler(self, fake_monitor, fake_monitor_device):


### PR DESCRIPTION
Closes #499 

pytest 8 removed the hook that was calling nose-specific methods, such as setup and teardown. However, there is still support for that, the methods just have _method on the end, so change them both.