### PR TITLE
Include the tests, and all sub-modules in the sdist

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,9 +29,14 @@ python_requires = >=3.7
 
 package_dir =
     =src
+    tests=tests
 
 packages =
     pyudev
     pyudev._ctypeslib
     pyudev.device
     pyudev._os
+    tests
+    tests.utils
+    tests.plugins
+    tests._device_tests


### PR DESCRIPTION
The current [sdist on PyPI](https://files.pythonhosted.org/packages/c4/5c/6cc034da13830e3da123ccf9a30910bc868fa16670362f004e4b788d0df1/pyudev-0.24.3.tar.gz) for version 0.24.3 contains only a partial copy of the `tests/` directory.

I'm not entirely sure why/how this happened; I don't see anything obvious that would cause it in `setup.cfg` or `pyproject.toml` but running `python3 -m build` locally does mimic the behaviour seen in the PyPI package. This PR adds a few clauses to `setup.cfg` to include the full test-suite in the sdist.

**Context:** I was investigating the [failure of the pyudev test suite](https://objectstorage.prodstack5.canonical.com/swift/v1/AUTH_0f9aae918d5b4744bf7b827671c86842/autopkgtest-plucky/plucky/amd64/p/pyudev/20250111_125308_8bc52@/log.gz) on the Ubuntu version of the package, and discovered that much of the test-suite [was missing](https://git.launchpad.net/ubuntu/+source/pyudev/tree/tests?h=ubuntu/plucky-devel). Our copy of the source is derived from Debian's, which in turn is derived [from the PyPI sdist](https://salsa.debian.org/python-team/packages/pyudev/-/blob/debian/master/debian/watch?ref_type=heads).

Given that the sdist has previously incorporated the full test-suite (e.g. in version 0.24.1 most recently), I'm guessing the desire is to continue providing it. If you wish to simply exclude the test-suite from the sdist, I'm happy to amend the PR to achieve that instead.