### PR TITLE
Add device attribute unset()

### DIFF
--- a/src/pyudev/device/_device.py
+++ b/src/pyudev/device/_device.py
@@ -1244,6 +1244,17 @@ class Attributes:
         """
         return string_to_bool(self.asstring(attribute))
 
+    def unset(self, attribute):
+        """
+        Clear the attribute's cached value in udev.
+
+        :param attribute: the key for an attribute value
+        :type attribute: unicode or byte string
+        """
+        self._libudev.udev_device_set_sysattr_value(
+            self.device, ensure_byte_string(attribute), None
+        )
+
 
 class Tags(collections.abc.Iterable, collections.abc.Container):
     """

--- a/tests/_device_tests/_attributes_tests.py
+++ b/tests/_device_tests/_attributes_tests.py
@@ -130,3 +130,13 @@ class TestAttributes:
                     pass
                 except ValueError:
                     pass
+
+    @given(_CONTEXT_STRATEGY, strategies.sampled_from(_DEVICE_DATA))
+    @settings(max_examples=5)
+    def test_unsetitem(self, a_context, device_datum):
+        """
+        Test that attribute value can be unset.
+        """
+        device = Devices.from_path(a_context, device_datum.device_path)
+        for key in device_datum.attributes.keys():
+            device.attributes.unset(key)


### PR DESCRIPTION
udev device attribute values are cached. Their actual values can change, but there is currently no way to update the cached value.

So introduce an `Attributes.unset()` method. Since the return value of `udev_device_set_sysattr_value()` is already checked internally, no further checks are required.

udev does not care whether the attribute exists, so no test for non-existent attributes is added.
