### PR TITLE
fix: correct typos in tests and docs

### DIFF
--- a/doc/guide.rst
+++ b/doc/guide.rst
@@ -346,7 +346,7 @@ with None is an error.
 
 The Device class inherits from the abstract Mapping class, as it maps udev
 property names to their values. Consequently, if a Device object has no udev
-properties, an unusual but not impossible occurance, the object is
+properties, an unusual but not impossible occurrence, the object is
 interpreted as False in a boolean context.
 
 .. _pypi: https://pypi.python.org/pypi/pyudev

--- a/tests/_constants.py
+++ b/tests/_constants.py
@@ -55,7 +55,7 @@ def device_strategy(require_existing=True, filter_func=lambda x: True):
     The devices are filtered before being sampled to reduce the number
     of health failures.
 
-    :param bool require_existing: at the very last, verify existance
+    :param bool require_existing: at the very last, verify existence
     :param filter_func: a function to be used as a filter
     :type filter_func: Device -> bool
     """

--- a/tests/utils/udev.py
+++ b/tests/utils/udev.py
@@ -209,7 +209,7 @@ class DeviceData:
     @property
     def exists(self):
         """
-        Whether this device has some real existance on machine.
+        Whether this device has some real existence on machine.
 
         :returns: True if the device does exist, otherwise False.
         :rtype: bool


### PR DESCRIPTION
- existance → existence (2x)
- occurance → occurrence