### PR TITLE
tests: remove unused imports from attribute tests

### DIFF
--- a/tests/_device_tests/_attributes_tests.py
+++ b/tests/_device_tests/_attributes_tests.py
@@ -20,16 +20,13 @@ Tests methods belonging to Attributes class.
 .. moduleauthor::  mulhern <amulhern@redhat.com>
 """
 
-import os
-import stat
-
 import pytest
 from hypothesis import given, settings, strategies
 
 from pyudev import Devices
 
 from ..utils import is_unicode_string
-from ._device_tests import _CONTEXT_STRATEGY, _DEVICE_DATA, _DEVICES, _UDEV_TEST
+from ._device_tests import _CONTEXT_STRATEGY, _DEVICE_DATA, _DEVICES
 
 
 class TestAttributes:


### PR DESCRIPTION
### Problem

`tests/_device_tests/_attributes_tests.py` still contains three imports
that are no longer used:

- `os`
- `stat`
- `_UDEV_TEST`

They were previously used by `test_available_attributes()`, which was
removed as a flaky test.

### Fix

Remove the stale imports.

### Testing

Verified with:

```text
PYTHONPATH=src pylint tests/_device_tests/_attributes_tests.py \
  --reports=no --disable=all --enable=unused-import
```

and:
```text
PYTHONPATH=src pytest tests/test_device.py -k TestAttributes
```